### PR TITLE
[deploy] Agrega stack docker con Postgres y API

### DIFF
--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -1,0 +1,75 @@
+# Nombre de archivo: compose.yml
+# Ubicación de archivo: deploy/compose.yml
+# Descripción: Stack base con PostgreSQL + API FastAPI + healthchecks y volumen persistente
+version: "3.9"
+
+name: lasfocas
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: lasfocas-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    ports:
+      - "5432:5432" # Cambiar host-port si está ocupado
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./db/init.sql:/docker-entrypoint-initdb.d/00-init.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB} -h localhost"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+    networks:
+      - lasfocas_net
+
+  api:
+    build:
+      context: ./api
+      dockerfile: Dockerfile
+    container_name: lasfocas-api
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      # Aseguramos que el host de DB sea el nombre del servicio de compose
+      POSTGRES_HOST: postgres
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "8000:8000"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8000/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+    networks:
+      - lasfocas_net
+
+  # (Opcional) pgAdmin. Levantar con: docker compose -f deploy/compose.yml --profile pgadmin up -d
+  pgadmin:
+    image: dpage/pgadmin4:8
+    container_name: lasfocas-pgadmin
+    profiles: ["pgadmin"]
+    restart: unless-stopped
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@local
+      PGADMIN_DEFAULT_PASSWORD: admin
+    ports:
+      - "5050:80"
+    depends_on:
+      - postgres
+    networks:
+      - lasfocas_net
+
+volumes:
+  postgres_data:
+
+networks:
+  lasfocas_net:
+    driver: bridge


### PR DESCRIPTION
## Resumen
- agrega compose con servicios de PostgreSQL, API FastAPI y pgAdmin opcional
- define volumen persistente y red bridge

## Pruebas
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689caed365a88330b6d4883835de5dfb