### PR TITLE
[api] Añadir Dockerfile base con healthcheck

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,31 @@
+# Nombre de archivo: Dockerfile
+# Ubicación de archivo: api/Dockerfile
+# Descripción: Imagen minimal para FastAPI (Python 3.11) con healthcheck por curl
+
+FROM python:3.11-slim
+
+# Evitar prompts interactivos y cache de pip
+ENV PIP_NO_CACHE_DIR=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# Dependencias del sistema mínimas (curl para healthcheck)
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Requisitos primero para aprovechar cache
+COPY requirements.txt /app/requirements.txt
+RUN python -m pip install --upgrade pip && pip install -r requirements.txt
+
+# Copiamos el código de la app
+COPY app /app/app
+
+EXPOSE 8000
+# Healthcheck simple con curl
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 \
+  CMD curl -f http://localhost:8000/health || exit 1
+
+# Arranque de la API
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Resumen
- Añade Dockerfile mínimo para desplegar la API FastAPI.
- Incluye healthcheck con curl para monitorear la disponibilidad del servicio.

## Pruebas
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689caee1bbc48330886bcd452a669a46