### PR TITLE
Agregar dependencias base para la API

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,0 +1,9 @@
+# Nombre de archivo: requirements.txt
+# Ubicación de archivo: api/requirements.txt
+# Descripción: Dependencias de la API base (FastAPI + SQLAlchemy + Psycopg 3)
+fastapi==0.112.2
+uvicorn[standard]==0.30.6
+pydantic==2.9.2
+SQLAlchemy==2.0.36
+psycopg[binary]==3.2.1
+python-dotenv==1.0.1


### PR DESCRIPTION
## Resumen
- Añadir `api/requirements.txt` con FastAPI, Uvicorn, Pydantic, SQLAlchemy, Psycopg y python-dotenv

## Pruebas
- `pip install -r api/requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689caf23762c83309e395e8006e82439