### PR TITLE
Agregar .dockerignore para la API

### DIFF
--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,0 +1,12 @@
+# Nombre de archivo: .dockerignore
+# Ubicación de archivo: api/.dockerignore
+# Descripción: Ignorar archivos no necesarios en el build de la imagen
+__pycache__/
+*.py[cod]
+*.log
+*.sqlite3
+.venv/
+.env
+.git/
+.gitignore
+tests/


### PR DESCRIPTION
## Resumen
- Añadir archivo `.dockerignore` para excluir archivos temporales y de desarrollo durante el build de la imagen Docker del servicio API.

## Pruebas
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689caf2b4e1c8330a0e33e6d96608d5d