### PR TITLE
[api] Inicializa paquete de rutas

### DIFF
--- a/api/app/routes/__init__.py
+++ b/api/app/routes/__init__.py
@@ -1,0 +1,15 @@
+# Nombre de archivo: __init__.py
+# Ubicación de archivo: api/app/routes/__init__.py
+# Descripción: Init del paquete routes
+
+"""Configuración inicial del paquete de rutas de la API.
+
+Se crea un objeto ``APIRouter`` que se utilizará para registrar y
+agrupar todas las rutas del servicio.
+"""
+
+from fastapi import APIRouter
+
+router = APIRouter()
+
+__all__ = ["router"]


### PR DESCRIPTION
## Resumen
- Crea estructura `api/app/routes` con archivo de inicialización
- Define `APIRouter` base para agrupar futuras rutas de la API

## Pruebas
- `python -m py_compile api/app/routes/__init__.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689caf429d0c8330a13b35da819072e9