### PR TITLE
[api] Añade módulo de conexión a PostgreSQL

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,3 @@
+# Nombre de archivo: __init__.py
+# Ubicación de archivo: api/__init__.py
+# Descripción: Inicializa el paquete api

--- a/api/app/__init__.py
+++ b/api/app/__init__.py
@@ -1,0 +1,3 @@
+# Nombre de archivo: __init__.py
+# Ubicación de archivo: api/app/__init__.py
+# Descripción: Inicializa el subpaquete app

--- a/api/app/db.py
+++ b/api/app/db.py
@@ -1,0 +1,28 @@
+# Nombre de archivo: db.py
+# Ubicación de archivo: api/app/db.py
+# Descripción: Conexión básica a PostgreSQL usando SQLAlchemy + Psycopg 3
+from os import getenv
+from sqlalchemy import create_engine, text
+import logging
+
+logger = logging.getLogger(__name__)
+
+DB_HOST = getenv("POSTGRES_HOST", "postgres")
+DB_PORT = getenv("POSTGRES_PORT", "5432")
+DB_NAME = getenv("POSTGRES_DB", "lasfocas")
+DB_USER = getenv("POSTGRES_USER", "lasfocas")
+DB_PASS = getenv("POSTGRES_PASSWORD", "cambiar-este-password")
+
+DSN = f"postgresql+psycopg://{DB_USER}:{DB_PASS}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
+
+engine = create_engine(DSN, pool_pre_ping=True, pool_recycle=1800)
+
+
+def db_health() -> dict:
+    """Realiza un SELECT 1 y devuelve info básica."""
+    logger.debug("Ejecutando verificación de salud de la base de datos")
+    with engine.connect() as conn:
+        conn.execute(text("SELECT 1"))
+        server_version = conn.exec_driver_sql("SHOW server_version").scalar()
+    logger.debug("Verificación completada con versión %s", server_version)
+    return {"db": "ok", "server_version": server_version}

--- a/docs/db.md
+++ b/docs/db.md
@@ -1,0 +1,15 @@
+# Nombre de archivo: db.md
+# Ubicación de archivo: docs/db.md
+# Descripción: Documentación del módulo de conexión a PostgreSQL
+
+El módulo `api/app/db.py` establece una conexión a PostgreSQL utilizando SQLAlchemy y Psycopg 3.
+La cadena DSN se construye a partir de variables de entorno:
+
+- `POSTGRES_HOST`: dirección del servidor de base de datos.
+- `POSTGRES_PORT`: puerto del servicio.
+- `POSTGRES_DB`: nombre de la base de datos.
+- `POSTGRES_USER`: usuario para la conexión.
+- `POSTGRES_PASSWORD`: contraseña del usuario.
+
+La función `db_health` ejecuta una consulta simple `SELECT 1` y obtiene la versión del servidor
+para verificar el estado de la base de datos.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+# Nombre de archivo: requirements.txt
+# Ubicación de archivo: requirements.txt
+# Descripción: Dependencias del proyecto LAS-FOCAS
+
+sqlalchemy
+psycopg[binary]


### PR DESCRIPTION
## Resumen
- agrega paquete `api` y subpaquete `app`
- incorpora módulo `db` con conexión a PostgreSQL mediante SQLAlchemy y Psycopg 3
- documenta el módulo y registra dependencias necesarias

## Pruebas
- `python -m py_compile api/app/db.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689caf4b07a483308212e97dac93eb36