### PR TITLE
[api] Añade endpoints de salud y verificación de DB

### DIFF
--- a/api/app/routes/health.py
+++ b/api/app/routes/health.py
@@ -1,0 +1,31 @@
+# Nombre de archivo: health.py
+# Ubicación de archivo: api/app/routes/health.py
+# Descripción: Endpoints de health y verificación de DB
+from datetime import datetime, timezone
+import logging
+
+from fastapi import APIRouter
+
+from app.db import db_health
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.get("/health")
+def health():
+    """Devuelve el estado básico del servicio."""
+    logger.info("Verificación de estado solicitada")
+    return {
+        "status": "ok",
+        "service": "api",
+        "time": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+@router.get("/db-check")
+def db_check():
+    """Verifica conectividad con la base de datos."""
+    logger.info("Verificación de base de datos solicitada")
+    return db_health()


### PR DESCRIPTION
## Resumen
- Agrega router de salud con endpoints `/health` y `/db-check`
- Implementa registro de logs para las solicitudes
- Documenta cada endpoint con docstrings

## Pruebas
- `python -m py_compile api/app/routes/health.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689caf565f408330b957858061c890da