### PR TITLE
[api] Añade aplicación FastAPI con ruta de salud

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,4 @@
+# Nombre de archivo: __init__.py
+# Ubicación de archivo: api/__init__.py
+# Descripción: Inicializa el paquete principal de la API
+"""Paquete principal de la API."""

--- a/api/app/__init__.py
+++ b/api/app/__init__.py
@@ -1,0 +1,4 @@
+# Nombre de archivo: __init__.py
+# Ubicación de archivo: api/app/__init__.py
+# Descripción: Inicializa el subpaquete de la aplicación FastAPI
+"""Subpaquete de la aplicación FastAPI."""

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -1,0 +1,20 @@
+# Nombre de archivo: main.py
+# Ubicación de archivo: api/app/main.py
+# Descripción: Aplicación FastAPI principal (incluye rutas de health)
+
+import logging
+from fastapi import FastAPI
+from .routes.health import router as health_router
+
+logger = logging.getLogger(__name__)
+
+
+def create_app() -> FastAPI:
+    """Crea y configura la instancia principal de FastAPI."""
+    logger.debug("Creando aplicación FastAPI")
+    app = FastAPI(title="LAS-FOCAS API", version="0.1.0")
+    app.include_router(health_router, tags=["health"])
+    return app
+
+
+app = create_app()

--- a/api/app/routes/__init__.py
+++ b/api/app/routes/__init__.py
@@ -1,0 +1,4 @@
+# Nombre de archivo: __init__.py
+# Ubicación de archivo: api/app/routes/__init__.py
+# Descripción: Inicializa el subpaquete de rutas de la API
+"""Subpaquete con las rutas de la API."""

--- a/api/app/routes/health.py
+++ b/api/app/routes/health.py
@@ -1,0 +1,17 @@
+# Nombre de archivo: health.py
+# Ubicación de archivo: api/app/routes/health.py
+# Descripción: Define la ruta de verificación del servicio
+
+import logging
+from fastapi import APIRouter
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.get("/health", summary="Verifica el estado del servicio")
+def health_check() -> dict[str, str]:
+    """Devuelve el estado básico del servicio."""
+    logger.debug("Chequeo de salud solicitado")
+    return {"status": "ok"}

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,9 @@
+# Nombre de archivo: api.md
+# Ubicación de archivo: docs/api.md
+# Descripción: Documentación básica de la API y del endpoint de salud
+
+## Endpoint de salud
+
+- **Ruta:** `GET /health`
+- **Descripción:** Verifica el estado del servicio.
+- **Respuesta:** `{"status": "ok"}`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+# Nombre de archivo: requirements.txt
+# Ubicación de archivo: requirements.txt
+# Descripción: Dependencias del proyecto
+
+fastapi==0.110.1
+uvicorn[standard]==0.29.0
+pytest==8.3.2
+httpx==0.27.0

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,20 @@
+# Nombre de archivo: test_health.py
+# Ubicación de archivo: tests/test_health.py
+# Descripción: Pruebas para la ruta de health de la API
+
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient
+from api.app.main import app
+
+client = TestClient(app)
+
+
+def test_health_returns_ok() -> None:
+    """Verifica que el endpoint /health responde correctamente."""
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## Resumen
- Implementa la aplicación principal de FastAPI con inclusión de la ruta de salud
- Define el endpoint `/health` con registro de eventos
- Añade pruebas unitarias, documentación y dependencias necesarias

## Pruebas
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689caf61684083309ebcbc16be536d01