### PR TITLE
[bot] Integrar bot de Telegram con allowlist y long polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Automatizaciones operativas para Metrotel: generación de informes, asistente co
 
 - **Interfaces**
 
-  - **Telegram Bot** (primer canal de operación).
+  - **Telegram Bot** (primer canal de operación). Ver [docs/bot.md](docs/bot.md) para guía rápida.
   - **Web Panel** (autenticación simple, accesible por IP interna .28).
   - CLI opcional para utilidades.
 

--- a/bot_telegram/app.py
+++ b/bot_telegram/app.py
@@ -1,0 +1,40 @@
+# Nombre de archivo: app.py
+# Ubicación de archivo: bot_telegram/app.py
+# Descripción: Entrypoint del bot (aiogram 3.x) con long polling y Allowlist
+
+import asyncio
+import logging
+import os
+
+from aiogram import Bot, Dispatcher
+from aiogram.client.default import DefaultBotProperties
+from aiogram.enums import ParseMode
+
+from bot_telegram.filters.allowlist import AllowlistMiddleware
+from bot_telegram.handlers.basic import router as basic_router
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s - %(message)s")
+logger = logging.getLogger("bot")
+
+TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
+
+
+async def main():
+    if not TOKEN:
+        raise RuntimeError("Falta TELEGRAM_BOT_TOKEN en el entorno")
+
+    bot = Bot(token=TOKEN, default=DefaultBotProperties(parse_mode=ParseMode.HTML))
+    dp = Dispatcher()
+
+    # Allowlist
+    dp.message.middleware(AllowlistMiddleware())
+
+    # Routers
+    dp.include_router(basic_router)
+
+    logger.info("Iniciando bot LAS-FOCAS (long polling)…")
+    await dp.start_polling(bot, allowed_updates=dp.resolve_used_update_types())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/bot_telegram/filters/allowlist.py
+++ b/bot_telegram/filters/allowlist.py
@@ -1,0 +1,26 @@
+# Nombre de archivo: allowlist.py
+# Ubicación de archivo: bot_telegram/filters/allowlist.py
+# Descripción: Filtro/Middleware que limita el uso del bot a IDs permitidos desde TELEGRAM_ALLOWED_IDS
+
+from aiogram import BaseMiddleware
+from aiogram.types import Message, Update
+import os
+
+
+class AllowlistMiddleware(BaseMiddleware):
+    def __init__(self) -> None:
+        super().__init__()
+        raw = os.getenv("TELEGRAM_ALLOWED_IDS", "")
+        self.allowed_ids = {int(x.strip()) for x in raw.split(",") if x.strip().isdigit()}
+
+    async def __call__(self, handler, event: Update, data):
+        user_id = None
+        if hasattr(event, "message") and isinstance(event.message, Message):
+            user_id = event.message.from_user.id
+        elif hasattr(event, "callback_query") and event.callback_query is not None:
+            user_id = event.callback_query.from_user.id
+
+        if user_id is None or (self.allowed_ids and user_id not in self.allowed_ids):
+            # Silencioso: no responde a usuarios no permitidos
+            return
+        return await handler(event, data)

--- a/bot_telegram/handlers/basic.py
+++ b/bot_telegram/handlers/basic.py
@@ -1,0 +1,28 @@
+# Nombre de archivo: basic.py
+# Ubicación de archivo: bot_telegram/handlers/basic.py
+# Descripción: Comandos básicos (/start, /help, /ping) y handler de fallback
+
+from aiogram import Router
+from aiogram.types import Message
+
+router = Router()
+
+
+@router.message(commands={"start"})
+async def cmd_start(msg: Message):
+    await msg.answer("🦭 ¡Hola! Soy el bot de LAS-FOCAS. Probá /ping o /help.")
+
+
+@router.message(commands={"help"})
+async def cmd_help(msg: Message):
+    await msg.answer("Comandos disponibles:\n/start – bienvenida\n/ping – prueba de latencia\n/help – esta ayuda")
+
+
+@router.message(commands={"ping"})
+async def cmd_ping(msg: Message):
+    await msg.answer("pong 🏓")
+
+
+@router.message()
+async def fallback(msg: Message):
+    await msg.answer("No entendí. Probá /help 🤖")

--- a/bot_telegram/requirements.txt
+++ b/bot_telegram/requirements.txt
@@ -1,0 +1,5 @@
+# Nombre de archivo: requirements.txt
+# Ubicación de archivo: bot_telegram/requirements.txt
+# Descripción: Dependencias específicas del bot de Telegram
+
+aiogram==3.13.1

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -51,6 +51,16 @@ services:
     networks:
       - lasfocas_net
 
+  bot:
+    build:
+      context: ..
+      dockerfile: deploy/docker/bot.Dockerfile
+    env_file:
+      - ../.env
+    depends_on:
+      - api
+    restart: unless-stopped
+
   # (Opcional) pgAdmin. Levantar con: docker compose -f deploy/compose.yml --profile pgadmin up -d
   pgadmin:
     image: dpage/pgadmin4:8

--- a/deploy/docker/bot.Dockerfile
+++ b/deploy/docker/bot.Dockerfile
@@ -1,0 +1,22 @@
+# Nombre de archivo: bot.Dockerfile
+# Ubicación de archivo: deploy/docker/bot.Dockerfile
+# Descripción: Imagen del bot de Telegram (aiogram, Python 3.11-slim)
+
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# Instalación de dependencias del bot
+COPY bot_telegram/requirements.txt /app/bot_requirements.txt
+RUN pip install --no-cache-dir -r /app/bot_requirements.txt
+
+# Copiamos solo lo necesario del proyecto
+COPY bot_telegram /app/bot_telegram
+
+# Usuario no root opcional (hardening)
+# RUN useradd -m bot && chown -R bot:bot /app && USER bot
+
+CMD ["python", "-m", "bot_telegram.app"]

--- a/docs/bot.md
+++ b/docs/bot.md
@@ -1,0 +1,58 @@
+# Nombre de archivo: bot.md
+# Ubicación de archivo: docs/bot.md
+# Descripción: Guía rápida de uso del bot de Telegram
+
+## Variables requeridas (.env)
+- TELEGRAM_BOT_TOKEN=...
+- TELEGRAM_ALLOWED_IDS=11111111,22222222
+
+## Arranque con Docker
+```bash
+docker compose -f deploy/compose.yml up -d --build bot
+docker compose -f deploy/compose.yml logs -f bot
+```
+
+## Prueba
+
+Enviar /start desde un ID permitido.
+
+Probar /ping y /help.
+
+Ver logs para validar que usuarios no permitidos no reciben respuesta.
+
+## Notas
+
+Modo: long polling (no requiere URL pública).
+
+Futuro: migrar a webhooks (reverse proxy + TLS) si se necesita menor latencia.
+
+---
+
+## Acciones para el Usuario (VM)
+1. **Agregar variables al `.env`** (si no están):
+
+```
+TELEGRAM_BOT_TOKEN=tu_token
+TELEGRAM_ALLOWED_IDS=11111111,22222222
+```
+
+2. **Levantar el servicio del bot**:
+```bash
+cd ~/proyectos/LAS-FOCAS
+docker compose -f deploy/compose.yml up -d --build bot
+docker compose -f deploy/compose.yml logs -f bot
+```
+
+Probar desde Telegram con un ID permitido: /start, /ping.
+
+## Siguientes pasos (tras validar “pong” 🏓)
+
+Conectar el bot a la API para comandos reales (ej. “/repetitividad mes=08 año=2025” → job en worker o API).
+
+Añadir /status que consulte http://api:8000/health.
+
+Registrar métricas de uso y logs estructurados.
+
+Añadir menú de comandos y ayudas contextuales.
+
+(Luego) migrar a webhooks detrás de un reverse proxy (cuando haya URL pública/SSL).


### PR DESCRIPTION
## Resumen
- Añadido middleware de allowlist y handlers básicos para el bot de Telegram
- Implementado entrypoint con long polling y Dockerfile dedicado
- Integrado servicio `bot` en docker compose y documentación rápida

## Pruebas
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7493d6abc83309b8191cdb4ecaa3a