### PR TITLE
[nlp] Microservicio de intención y flujo básico en bot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,3 +50,8 @@ Este documento está diseñado para orientar a **CODEX** en la comprensión del 
 8.	Docker: Mantener imágenes ligeras y basadas en versiones específicas, no usar latest.
 9.	Dependencias: Actualizar requirements.txt al añadir librerías y verificar compatibilidad.
 10.	Integraciones externas: Probar en entornos de staging antes de aplicar a producción.
+
+## 🆕 Módulo nlp_intent
+
+Microservicio FastAPI para clasificación de intención (Consulta, Acción, Otros). Ver `docs/nlp/intent.md` para detalles.
+

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Automatizaciones operativas para Metrotel: generación de informes, asistente co
 
   - **Telegram Bot** (primer canal de operación). Ver [docs/bot.md](docs/bot.md) para guía rápida.
   - **Web Panel** (autenticación simple, accesible por IP interna .28).
+  - **nlp_intent** (microservicio NLP para clasificación de intención).
   - CLI opcional para utilidades.
 
 - **Integraciones externas**
@@ -69,6 +70,10 @@ Automatizaciones operativas para Metrotel: generación de informes, asistente co
         │ Telegram Bot   │  ← Allowlist de IDs
         └─────────┘
 
+        ┌───────────────┐
+        │ nlp_intent    │  ← Clasificación de intención
+        └───────────────┘
+
         ┌─────────┐
         │ Notion/Email   │  (Integraciones)
         └─────────┘
@@ -96,6 +101,7 @@ Automatizaciones operativas para Metrotel: generación de informes, asistente co
 las-focas/
 ├─ api/
 ├─ bot_telegram/
+├─ nlp_intent/
 ├─ core/
 ├─ modules/
 ├─ workers/
@@ -134,6 +140,13 @@ SMTP_HOST=smtp.example.com
 SMTP_PORT=587
 SMTP_USER=notificaciones@example.com
 SMTP_PASS=secret
+# NLP / LLM
+LLM_PROVIDER=auto
+OPENAI_API_KEY=
+OLLAMA_URL=http://ollama:11434
+INTENT_THRESHOLD=0.7
+LANG=es
+LOG_RAW_TEXT=false
 ```
 
 ---

--- a/bot_telegram/app.py
+++ b/bot_telegram/app.py
@@ -11,6 +11,7 @@ from aiogram.client.default import DefaultBotProperties
 from aiogram.enums import ParseMode
 
 from bot_telegram.filters.allowlist import AllowlistMiddleware
+from bot_telegram.handlers.intent import router as intent_router
 from bot_telegram.handlers.basic import router as basic_router
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s - %(message)s")
@@ -30,6 +31,7 @@ async def main():
     dp.message.middleware(AllowlistMiddleware())
 
     # Routers
+    dp.include_router(intent_router)
     dp.include_router(basic_router)
 
     logger.info("Iniciando bot LAS-FOCAS (long polling)…")

--- a/bot_telegram/handlers/intent.py
+++ b/bot_telegram/handlers/intent.py
@@ -1,0 +1,85 @@
+# Nombre de archivo: intent.py
+# Ubicación de archivo: bot_telegram/handlers/intent.py
+# Descripción: Manejo de mensajes de texto con clasificación de intención y persistencia
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from collections import defaultdict
+
+import httpx
+import psycopg
+from aiogram import Router, F
+from aiogram.types import Message
+
+from core.repositories.conversations import insert_conversation
+from core.repositories.messages import insert_message
+
+router = Router()
+_rate_limit: dict[int, list[float]] = defaultdict(list)
+_conversations: dict[int, int] = {}
+
+
+def _check_rate(user_id: int, limit: int = 20, interval: int = 60) -> bool:
+    now = time.time()
+    times = _rate_limit[user_id]
+    times[:] = [t for t in times if now - t < interval]
+    if len(times) >= limit:
+        return False
+    times.append(now)
+    return True
+
+
+def _get_conn() -> psycopg.Connection:
+    return psycopg.connect(
+        host=os.getenv("POSTGRES_HOST", "localhost"),
+        dbname=os.getenv("POSTGRES_DB"),
+        user=os.getenv("POSTGRES_USER"),
+        password=os.getenv("POSTGRES_PASSWORD"),
+    )
+
+
+@router.message(F.text)
+async def classify_message(msg: Message):
+    user_id = msg.from_user.id
+    if not _check_rate(user_id):
+        await msg.answer("Rate limit alcanzado. Esperá un momento ⏳")
+        return
+
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        resp = await client.post("http://nlp_intent:8100/v1/intent:classify", json={"text": msg.text})
+        data = resp.json()
+
+    conn = await asyncio.to_thread(_get_conn)
+    conversation_id = _conversations.get(user_id)
+    if conversation_id is None:
+        conversation_id = await asyncio.to_thread(insert_conversation, conn, user_id)
+        _conversations[user_id] = conversation_id
+    await asyncio.to_thread(
+        insert_message,
+        conn,
+        conversation_id,
+        user_id,
+        "user",
+        msg.text,
+        data["normalized_text"],
+        data["intent"],
+        data["confidence"],
+        data["provider"],
+    )
+    conn.close()
+
+    summary = f"Intención: {data['intent']} (confianza: {data['confidence']:.2f})."
+    threshold = float(os.getenv("INTENT_THRESHOLD", "0.7"))
+    if data["confidence"] < threshold:
+        await msg.answer("No estoy 100% seguro 🤔 ¿Querías hacer una acción o consultar algo?\n" + summary)
+    elif data["intent"] == "Acción":
+        await msg.answer(
+            "📋 Acción detectada. Implementación pendiente. En breve se habilitará este flujo.\n" + summary
+        )
+    else:
+        await msg.answer(summary)
+
+

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,4 @@
+# Nombre de archivo: __init__.py
+# Ubicación de archivo: core/__init__.py
+# Descripción: Inicializa el paquete de utilidades centrales
+

--- a/core/repositories/__init__.py
+++ b/core/repositories/__init__.py
@@ -1,0 +1,4 @@
+# Nombre de archivo: __init__.py
+# Ubicación de archivo: core/repositories/__init__.py
+# Descripción: Inicializa el submódulo de repositorios de base de datos
+

--- a/core/repositories/conversations.py
+++ b/core/repositories/conversations.py
@@ -1,0 +1,27 @@
+# Nombre de archivo: conversations.py
+# Ubicación de archivo: core/repositories/conversations.py
+# Descripción: Funciones para gestionar la tabla de conversaciones
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import psycopg
+
+logger = logging.getLogger(__name__)
+
+
+def insert_conversation(conn: psycopg.Connection, tg_user_id: int) -> int:
+    """Inserta una nueva conversación y devuelve su ID."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO app.conversations (tg_user_id) VALUES (%s) RETURNING id",
+            (tg_user_id,),
+        )
+        new_id = cur.fetchone()[0]
+        conn.commit()
+    logger.info("conversación creada", extra={"tg_user_id": tg_user_id, "conversation_id": new_id})
+    return new_id
+
+

--- a/core/repositories/messages.py
+++ b/core/repositories/messages.py
@@ -1,0 +1,57 @@
+# Nombre de archivo: messages.py
+# Ubicación de archivo: core/repositories/messages.py
+# Descripción: Funciones para insertar mensajes en la base de datos
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import psycopg
+
+logger = logging.getLogger(__name__)
+
+
+def insert_message(
+    conn: psycopg.Connection,
+    conversation_id: int,
+    tg_user_id: int,
+    role: str,
+    text: str,
+    normalized_text: str,
+    intent: str,
+    confidence: float,
+    provider: str,
+) -> None:
+    """Inserta un mensaje asociado a una conversación."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO app.messages (
+                conversation_id, tg_user_id, role, text, normalized_text,
+                intent, confidence, provider
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            """,
+            (
+                conversation_id,
+                tg_user_id,
+                role,
+                text,
+                normalized_text,
+                intent,
+                confidence,
+                provider,
+            ),
+        )
+        conn.commit()
+    logger.info(
+        "mensaje guardado",
+        extra={
+            "conversation_id": conversation_id,
+            "tg_user_id": tg_user_id,
+            "intent": intent,
+            "confidence": confidence,
+        },
+    )
+
+

--- a/db/init.sql
+++ b/db/init.sql
@@ -11,3 +11,28 @@ CREATE TABLE IF NOT EXISTS app.example (
     note TEXT
 );
 
+
+-- Tabla de conversaciones
+CREATE TABLE IF NOT EXISTS app.conversations (
+    id SERIAL PRIMARY KEY,
+    tg_user_id BIGINT NOT NULL,
+    started_at TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW()
+);
+
+-- Tabla de mensajes
+CREATE TABLE IF NOT EXISTS app.messages (
+    id SERIAL PRIMARY KEY,
+    conversation_id INTEGER REFERENCES app.conversations(id),
+    tg_user_id BIGINT,
+    role TEXT NOT NULL,
+    text TEXT NOT NULL,
+    normalized_text TEXT,
+    intent TEXT,
+    confidence NUMERIC,
+    provider TEXT,
+    created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_messages_user ON app.messages(tg_user_id);
+CREATE INDEX IF NOT EXISTS idx_messages_created ON app.messages(created_at);
+

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -51,6 +51,18 @@ services:
     networks:
       - lasfocas_net
 
+  nlp_intent:
+    build:
+      context: ..
+      dockerfile: deploy/docker/nlp_intent.Dockerfile
+    env_file:
+      - ../.env
+    expose:
+      - "8100"
+    restart: unless-stopped
+    networks:
+      - lasfocas_net
+
   bot:
     build:
       context: ..

--- a/deploy/docker/nlp_intent.Dockerfile
+++ b/deploy/docker/nlp_intent.Dockerfile
@@ -1,0 +1,16 @@
+# Nombre de archivo: nlp_intent.Dockerfile
+# Ubicación de archivo: deploy/docker/nlp_intent.Dockerfile
+# Descripción: Imagen para el microservicio de clasificación de intención
+
+FROM python:3.11-slim
+WORKDIR /app
+
+COPY nlp_intent/requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r /app/requirements.txt
+
+COPY nlp_intent/app /app/app
+
+USER 1000:1000
+EXPOSE 8100
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8100"]

--- a/deploy/env.sample
+++ b/deploy/env.sample
@@ -1,0 +1,22 @@
+# Nombre de archivo: env.sample
+# Ubicación de archivo: deploy/env.sample
+# Descripción: Variables de entorno de ejemplo para desplegar servicios
+
+# Base de datos
+POSTGRES_HOST=postgres
+POSTGRES_PORT=5432
+POSTGRES_DB=lasfocas
+POSTGRES_USER=lasfocas
+POSTGRES_PASSWORD=superseguro
+
+# Bot de Telegram
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_ALLOWED_IDS=11111111,22222222
+
+# NLP / LLM
+LLM_PROVIDER=auto
+OPENAI_API_KEY=
+OLLAMA_URL=http://ollama:11434
+INTENT_THRESHOLD=0.7
+LANG=es
+LOG_RAW_TEXT=false

--- a/docs/bot.md
+++ b/docs/bot.md
@@ -20,6 +20,11 @@ Probar /ping y /help.
 
 Ver logs para validar que usuarios no permitidos no reciben respuesta.
 
+## Clasificación de intención
+
+Cada mensaje de texto se envía al microservicio `nlp_intent` para determinar si es una **Consulta**, una **Acción** u **Otros**.
+El bot responde con un resumen de la intención detectada. Si la confianza es baja, solicita una aclaración al usuario.
+
 ## Notas
 
 Modo: long polling (no requiere URL pública).

--- a/docs/nlp/intent.md
+++ b/docs/nlp/intent.md
@@ -1,0 +1,45 @@
+# Nombre de archivo: intent.md
+# Ubicación de archivo: docs/nlp/intent.md
+# Descripción: Documentación del microservicio nlp_intent
+
+# Microservicio `nlp_intent`
+
+Servicio FastAPI para clasificar mensajes de usuario en una de tres intenciones: **Consulta**, **Acción** u **Otros**.
+
+## Endpoint
+
+- `POST /v1/intent:classify`
+
+### Request
+```json
+{ "text": "generá el informe SLA de julio" }
+```
+
+### Response
+```json
+{
+  "intent": "Acción",
+  "confidence": 0.90,
+  "provider": "heuristic",
+  "normalized_text": "generá el informe sla de julio"
+}
+```
+
+## Orden de proveedores
+
+1. Heurística local (rápida).
+2. Ollama (`llama3`).
+3. OpenAI API.
+
+El servicio intenta cada proveedor en ese orden mientras la confianza sea menor al umbral configurado (`INTENT_THRESHOLD`, por defecto **0.7**).
+
+## Baja confianza
+
+Si `confidence < INTENT_THRESHOLD`, el bot pedirá una aclaración al usuario para mejorar la interpretación del mensaje.
+
+## Ejemplos de uso
+
+- "hola, ¿cómo va?" → Otros
+- "¿cómo genero el reporte de repetitividad?" → Consulta
+- "generá el reporte de repetitividad de agosto 2025" → Acción
+

--- a/nlp_intent/__init__.py
+++ b/nlp_intent/__init__.py
@@ -1,0 +1,4 @@
+# Nombre de archivo: __init__.py
+# Ubicación de archivo: nlp_intent/__init__.py
+# Descripción: Inicializa el paquete nlp_intent
+

--- a/nlp_intent/app/__init__.py
+++ b/nlp_intent/app/__init__.py
@@ -1,0 +1,4 @@
+# Nombre de archivo: __init__.py
+# Ubicación de archivo: nlp_intent/app/__init__.py
+# Descripción: Inicializa el módulo de la aplicación FastAPI
+

--- a/nlp_intent/app/config.py
+++ b/nlp_intent/app/config.py
@@ -1,0 +1,22 @@
+# Nombre de archivo: config.py
+# Ubicación de archivo: nlp_intent/app/config.py
+# Descripción: Manejo de configuración y variables de entorno para el servicio NLP
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass
+class Settings:
+    llm_provider: str = os.getenv("LLM_PROVIDER", "auto")
+    openai_api_key: str | None = os.getenv("OPENAI_API_KEY")
+    ollama_url: str = os.getenv("OLLAMA_URL", "http://ollama:11434")
+    intent_threshold: float = float(os.getenv("INTENT_THRESHOLD", "0.7"))
+    lang: str = os.getenv("LANG", "es")
+    log_raw_text: bool = os.getenv("LOG_RAW_TEXT", "false").lower() == "true"
+
+
+settings = Settings()
+

--- a/nlp_intent/app/main.py
+++ b/nlp_intent/app/main.py
@@ -1,0 +1,25 @@
+# Nombre de archivo: main.py
+# Ubicación de archivo: nlp_intent/app/main.py
+# Descripción: Servidor FastAPI para clasificación de intención de mensajes
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from .schemas import IntentRequest, IntentResponse
+from .service import classify_text
+
+app = FastAPI(title="nlp_intent")
+
+
+@app.post("/v1/intent:classify", response_model=IntentResponse)
+async def classify_endpoint(req: IntentRequest) -> IntentResponse:
+    """Clasifica el texto recibido en una intención."""
+    return await classify_text(req.text)
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+

--- a/nlp_intent/app/providers/__init__.py
+++ b/nlp_intent/app/providers/__init__.py
@@ -1,0 +1,4 @@
+# Nombre de archivo: __init__.py
+# Ubicación de archivo: nlp_intent/app/providers/__init__.py
+# Descripción: Inicializa el submódulo de proveedores NLP
+

--- a/nlp_intent/app/providers/heuristic.py
+++ b/nlp_intent/app/providers/heuristic.py
@@ -1,0 +1,29 @@
+# Nombre de archivo: heuristic.py
+# Ubicación de archivo: nlp_intent/app/providers/heuristic.py
+# Descripción: Clasificador basado en reglas simples para determinar la intención
+
+from __future__ import annotations
+
+import re
+from typing import Tuple
+
+ACTION_PATTERNS = re.compile(
+    r"\b(generar|generá|crear|creá|enviar|enviá|ejecutar|ejecutá|calcular|calculá|correr|corré|iniciar|iniciá|preparar|prepará|procesar|procesá|arma|armar|armá|comparar|compará|actualizar|actualizá|migrar|migrá)\b"
+)
+CONSULTA_PATTERNS = re.compile(
+    r"(\b(cómo|como|qué|que|cuándo|dónde|por\ qué|podés\ explicarme)\b|\?)"
+)
+OTROS_PATTERNS = re.compile(r"\b(hola|buen\s*día|gracias|qué\s*onda|buenas)\b")
+
+
+def classify(text: str) -> Tuple[str, float]:
+    """Clasifica texto usando reglas sencillas."""
+    if ACTION_PATTERNS.search(text):
+        return "Acción", 0.9
+    if CONSULTA_PATTERNS.search(text):
+        return "Consulta", 0.9
+    if OTROS_PATTERNS.search(text):
+        return "Otros", 0.8
+    return "Otros", 0.5
+
+

--- a/nlp_intent/app/providers/ollama_provider.py
+++ b/nlp_intent/app/providers/ollama_provider.py
@@ -1,0 +1,44 @@
+# Nombre de archivo: ollama_provider.py
+# Ubicación de archivo: nlp_intent/app/providers/ollama_provider.py
+# Descripción: Cliente para clasificar intención usando Ollama (modelo llama3)
+
+from __future__ import annotations
+
+import httpx
+import orjson
+
+from ..config import settings
+from ..schemas import IntentResponse
+
+PROMPT_TEMPLATE = (
+    "Clasificá el mensaje del usuario en exactamente una de: Consulta, Acción, Otros. "
+    'Devolvé solo JSON con: {"intent": "<Consulta|Acción|Otros>", '
+    '"confidence": 0.xx, "provider": "ollama", "normalized_text": "<texto_normalizado>"}\n'
+    "Ejemplos:\n"
+    "Usuario: hola, ¿cómo va?\n"
+    "Respuesta: {\"intent\": \"Otros\", \"confidence\": 0.9, \"provider\": \"ollama\", \"normalized_text\": \"hola, ¿cómo va?\"}\n"
+    "Usuario: ¿cómo genero el reporte de repetitividad?\n"
+    "Respuesta: {\"intent\": \"Consulta\", \"confidence\": 0.9, \"provider\": \"ollama\", \"normalized_text\": \"¿cómo genero el reporte de repetitividad?\"}\n"
+    "Usuario: generá el reporte de repetitividad de agosto 2025\n"
+    "Respuesta: {\"intent\": \"Acción\", \"confidence\": 0.9, \"provider\": \"ollama\", \"normalized_text\": \"generá el reporte de repetitividad de agosto 2025\"}\n"
+    "Usuario: podés explicarme qué hace el comparador de FO?\n"
+    "Respuesta: {\"intent\": \"Consulta\", \"confidence\": 0.9, \"provider\": \"ollama\", \"normalized_text\": \"podés explicarme qué hace el comparador de fo?\"}\n"
+    "Usuario: armá el informe SLA de julio\n"
+    "Respuesta: {\"intent\": \"Acción\", \"confidence\": 0.9, \"provider\": \"ollama\", \"normalized_text\": \"armá el informe sla de julio\"}\n"
+    "Usuario: {user_text}\n"
+    "Respuesta:"
+)
+
+
+async def classify(text: str, normalized_text: str) -> IntentResponse:
+    payload = {"model": "llama3", "prompt": PROMPT_TEMPLATE.format(user_text=text), "options": {"temperature": 0}}
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        resp = await client.post(f"{settings.ollama_url}/api/generate", json=payload)
+        resp.raise_for_status()
+        raw = resp.json().get("response", "{}")
+    data = orjson.loads(raw)
+    data.setdefault("provider", "ollama")
+    data.setdefault("normalized_text", normalized_text)
+    return IntentResponse(**data)
+
+

--- a/nlp_intent/app/providers/openai_provider.py
+++ b/nlp_intent/app/providers/openai_provider.py
@@ -1,0 +1,58 @@
+# Nombre de archivo: openai_provider.py
+# Ubicación de archivo: nlp_intent/app/providers/openai_provider.py
+# Descripción: Cliente para clasificar intención usando la API de OpenAI
+
+from __future__ import annotations
+
+import httpx
+import orjson
+
+from ..config import settings
+from ..schemas import IntentResponse
+
+SYSTEM_PROMPT = (
+    "Sos un clasificador de intenciones. "
+    "Clasificá el mensaje del usuario en exactamente una de: Consulta, Acción, Otros. "
+    'Devolvé solo JSON con: {"intent": "<Consulta|Acción|Otros>", "confidence": 0.xx, "provider": "openai", "normalized_text": "<texto_normalizado>"}'
+)
+
+FEW_SHOTS = [
+    ("hola, ¿cómo va?", "Otros"),
+    ("¿cómo genero el reporte de repetitividad?", "Consulta"),
+    ("generá el reporte de repetitividad de agosto 2025", "Acción"),
+    ("podés explicarme qué hace el comparador de FO?", "Consulta"),
+    ("armá el informe SLA de julio", "Acción"),
+]
+
+
+async def classify(text: str, normalized_text: str) -> IntentResponse:
+    messages = [{"role": "system", "content": SYSTEM_PROMPT}]
+    for sample, intent in FEW_SHOTS:
+        messages.append({"role": "user", "content": sample})
+        messages.append(
+            {
+                "role": "assistant",
+                "content": orjson.dumps(
+                    {
+                        "intent": intent,
+                        "confidence": 0.9,
+                        "provider": "openai",
+                        "normalized_text": sample,
+                    }
+                ).decode(),
+            }
+        )
+    messages.append({"role": "user", "content": text})
+
+    headers = {"Authorization": f"Bearer {settings.openai_api_key}"}
+    payload = {"model": "gpt-3.5-turbo", "temperature": 0, "messages": messages}
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        resp = await client.post("https://api.openai.com/v1/chat/completions", headers=headers, json=payload)
+        resp.raise_for_status()
+        content = resp.json()["choices"][0]["message"]["content"]
+    data = orjson.loads(content)
+    data.setdefault("provider", "openai")
+    data.setdefault("normalized_text", normalized_text)
+    return IntentResponse(**data)
+
+

--- a/nlp_intent/app/schemas.py
+++ b/nlp_intent/app/schemas.py
@@ -1,0 +1,25 @@
+# Nombre de archivo: schemas.py
+# Ubicación de archivo: nlp_intent/app/schemas.py
+# Descripción: Esquemas pydantic para solicitudes y respuestas del servicio
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class IntentRequest(BaseModel):
+    text: str = Field(..., description="Texto del usuario")
+
+
+class IntentResponse(BaseModel):
+    intent: Literal["Consulta", "Acción", "Otros"]
+    confidence: float
+    provider: str
+    normalized_text: str
+
+    class Config:
+        orm_mode = True
+
+

--- a/nlp_intent/app/service.py
+++ b/nlp_intent/app/service.py
@@ -1,0 +1,67 @@
+# Nombre de archivo: service.py
+# Ubicación de archivo: nlp_intent/app/service.py
+# Descripción: Orquestador de clasificación de intención y selección de proveedor
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+
+from .config import settings
+from .schemas import IntentResponse
+from .providers import heuristic, ollama_provider, openai_provider
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize(text: str) -> str:
+    return re.sub(r"\s+", " ", text.strip().lower())
+
+
+async def classify_text(text: str) -> IntentResponse:
+    normalized = _normalize(text)
+    hash_text = hashlib.sha256(text.encode()).hexdigest()
+    log_extra = {"len_text": len(text), "hash_sha256": hash_text}
+
+    if settings.llm_provider in ("heuristic", "auto"):
+        intent, confidence = heuristic.classify(normalized)
+        logger.info(
+            "clasificación",
+            extra={**log_extra, "provider": "heuristic", "intent": intent, "confidence": confidence},
+        )
+        if settings.llm_provider != "auto" or confidence >= settings.intent_threshold:
+            return IntentResponse(
+                intent=intent,
+                confidence=confidence,
+                provider="heuristic",
+                normalized_text=normalized,
+            )
+
+    if settings.llm_provider in ("ollama", "auto"):
+        try:
+            resp = await ollama_provider.classify(text, normalized)
+            logger.info(
+                "clasificación",
+                extra={**log_extra, "provider": resp.provider, "intent": resp.intent, "confidence": resp.confidence},
+            )
+            if settings.llm_provider != "auto" or resp.confidence >= settings.intent_threshold:
+                return resp
+        except Exception as exc:  # pragma: no cover - manejo de fallos externo
+            logger.warning("ollama_fallo", extra={**log_extra, "error": str(exc)})
+
+    if settings.llm_provider in ("openai", "auto"):
+        try:
+            resp = await openai_provider.classify(text, normalized)
+            logger.info(
+                "clasificación",
+                extra={**log_extra, "provider": resp.provider, "intent": resp.intent, "confidence": resp.confidence},
+            )
+            return resp
+        except Exception as exc:  # pragma: no cover
+            logger.warning("openai_fallo", extra={**log_extra, "error": str(exc)})
+
+    # Fallback final
+    return IntentResponse(intent="Otros", confidence=0.0, provider="none", normalized_text=normalized)
+
+

--- a/nlp_intent/requirements.txt
+++ b/nlp_intent/requirements.txt
@@ -1,0 +1,10 @@
+# Nombre de archivo: requirements.txt
+# Ubicación de archivo: nlp_intent/requirements.txt
+# Descripción: Dependencias específicas del microservicio nlp_intent
+
+fastapi==0.110.1
+uvicorn[standard]==0.29.0
+httpx==0.27.0
+pydantic==2.6.3
+orjson==3.10.3
+pytest==8.3.2

--- a/nlp_intent/tests/test_intent.py
+++ b/nlp_intent/tests/test_intent.py
@@ -1,0 +1,46 @@
+# Nombre de archivo: test_intent.py
+# Ubicación de archivo: nlp_intent/tests/test_intent.py
+# Descripción: Pruebas del clasificador de intención con dataset mínimo
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+from nlp_intent.app.service import classify_text
+
+TEST_DATA = [
+    ("hola", "Otros"),
+    ("buen día", "Otros"),
+    ("gracias", "Otros"),
+    ("qué onda?", "Otros"),
+    ("¿cómo genero el informe de repetitividad?", "Consulta"),
+    ("qué es el comparador de FO?", "Consulta"),
+    ("podés explicarme SLA?", "Consulta"),
+    ("generá el informe SLA de julio", "Acción"),
+    ("armá el reporte de repetitividad de agosto 2025", "Acción"),
+    ("enviá el informe por correo", "Acción"),
+    ("ejecutá el comparador FO contra archivo X", "Acción"),
+    ("actualizá los datos", "Acción"),
+]
+
+
+def test_dataset_accuracy(monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER", "heuristic")
+
+    async def _run():
+        hits = 0
+        for text, expected in TEST_DATA:
+            resp = await classify_text(text)
+            if resp.intent == expected:
+                hits += 1
+        return hits / len(TEST_DATA)
+
+    accuracy = asyncio.run(_run())
+    assert accuracy >= 0.9
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pytest==8.3.2
 httpx==0.27.0
 sqlalchemy
 psycopg[binary]
+orjson


### PR DESCRIPTION
## Resumen
- agrega servicio `nlp_intent` con FastAPI y estrategia híbrida de heurísticas/Ollama/OpenAI
- integra clasificación de intención y persistencia de mensajes en el bot de Telegram
- documenta variables de entorno y añade Dockerfile/compose para el nuevo servicio

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7502b98f08330ad8c9f5b401cb0be