### PR TITLE
[bot] Implementa informe de repetitividad y teclado de atajos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ Thumbs.db
 # Docker
 docker-data/
 .docker/
+
+# Datos de informes
+data/uploads/
+data/reports/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,7 @@ Todos los prompts deben seguir este esquema **en este orden**:
 * **Acción detectada**: si el flujo no existe, responder “implementación pendiente” y registrar intención para backlog.
 * **Menú principal**: cuando la intención sea "Acción" y el mensaje contenga palabras clave de menú, abrir el menú principal.
 * **Mensajes de sistema**: ser claros, breves y accionables.
+* **ReplyKeyboard**: disponible con atajos `/sla`, `/repetitividad`, `/menu` y `/hide` como alternativa a callbacks.
 
 ### 10) Rendimiento y resiliencia
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Automatizaciones operativas para Metrotel: generación de informes, asistente co
 
 - **Interfaces**
 
-  - **Telegram Bot** (primer canal de operación, con menú accesible por `/menu` o por intención). Ver [docs/bot.md](docs/bot.md) para guía rápida.
+  - **Telegram Bot** (primer canal de operación, con menú accesible por `/menu` o por intención). Incluye el flujo `/repetitividad` y un teclado opcional con atajos a `/sla` y `/repetitividad`. Ver [docs/bot.md](docs/bot.md) para guía rápida.
   - **Web Panel** (autenticación simple, accesible por IP interna .28).
   - **nlp_intent** (microservicio NLP para clasificación de intención).
   - CLI opcional para utilidades.

--- a/bot_telegram/app.py
+++ b/bot_telegram/app.py
@@ -13,6 +13,7 @@ from aiogram.enums import ParseMode
 from bot_telegram.filters.allowlist import AllowlistMiddleware
 from bot_telegram.handlers.basic import router as basic_router
 from bot_telegram.handlers.commands import router as commands_router
+from bot_telegram.flows.repetitividad import router as rep_router
 from bot_telegram.handlers.intent import router as intent_router
 from bot_telegram.handlers.menu import router as menu_router
 
@@ -35,6 +36,7 @@ async def main():
     dp.callback_query.middleware(allowlist)
 
     # Routers
+    dp.include_router(rep_router)
     dp.include_router(menu_router)
     dp.include_router(commands_router)
     dp.include_router(intent_router)

--- a/bot_telegram/flows/repetitividad.py
+++ b/bot_telegram/flows/repetitividad.py
@@ -1,24 +1,112 @@
 # Nombre de archivo: repetitividad.py
 # Ubicación de archivo: bot_telegram/flows/repetitividad.py
-# Descripción: Flujo unificado para el informe de repetitividad del bot
+# Descripción: Flujo para recibir Excel y generar el informe de repetitividad
 
 import logging
-from aiogram.types import Message
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
 
+from aiogram import F, Router
+from aiogram.filters import Command
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.state import State, StatesGroup
+from aiogram.types import FSInputFile, Message
+
+from modules.informes_repetitividad.config import BASE_UPLOADS
+from modules.informes_repetitividad.runner import run
+
+router = Router()
 logger = logging.getLogger(__name__)
 
 
-def build_repetitividad_response() -> str:
-    """Genera el texto base para el informe de repetitividad."""
-    return "📊 Informe de Repetitividad — implementación pendiente"
+class RepetitividadStates(StatesGroup):
+    WAITING_FILE = State()
+    WAITING_PERIOD = State()
 
 
-async def start_repetitividad_flow(msg: Message, origin: str) -> None:
-    """Inicia el flujo de Repetitividad enviando el mensaje estándar."""
+async def start_repetitividad_flow(msg: Message, state: FSMContext, origin: str) -> None:
+    """Inicia el flujo solicitando el archivo Excel."""
     tg_user_id = msg.from_user.id
     logger.info(
         "service=bot route=%s action=start_repetitividad_flow tg_user_id=%s",
         origin,
         tg_user_id,
     )
-    await msg.answer(build_repetitividad_response())
+    await state.clear()
+    await msg.answer(
+        "📊 Enviá el Excel 'Casos' en formato .xlsx o /cancel para salir"
+    )
+    await state.set_state(RepetitividadStates.WAITING_FILE)
+
+
+@router.message(RepetitividadStates.WAITING_FILE, F.document)
+async def on_file(msg: Message, state: FSMContext) -> None:
+    """Recibe y almacena el archivo enviado por el usuario."""
+    document = msg.document
+    if not document.file_name.lower().endswith(".xlsx"):
+        await msg.answer("El archivo debe tener extensión .xlsx. Intentá nuevamente")
+        return
+
+    user_dir = BASE_UPLOADS / "telegram" / str(msg.from_user.id)
+    user_dir.mkdir(parents=True, exist_ok=True)
+    file_path = user_dir / document.file_name
+    await document.download(destination=file_path)
+    await state.update_data(file_path=str(file_path))
+
+    prev_month = datetime.now().replace(day=1) - timedelta(days=1)
+    sugerencia = prev_month.strftime("%m/%Y")
+    await msg.answer(
+        f"Ingresá el período a analizar (mm/aaaa). Ejemplo: {sugerencia}"
+    )
+    await state.set_state(RepetitividadStates.WAITING_PERIOD)
+
+
+@router.message(RepetitividadStates.WAITING_FILE)
+async def on_invalid_file(msg: Message) -> None:
+    await msg.answer("Necesito un archivo .xlsx válido o /cancel para salir")
+
+
+@router.message(RepetitividadStates.WAITING_PERIOD, F.text)
+async def on_period(msg: Message, state: FSMContext) -> None:
+    """Procesa el período y genera el informe."""
+    texto = msg.text.strip()
+    try:
+        mes, anio = map(int, texto.split("/"))
+        if not (1 <= mes <= 12 and anio >= 2000):
+            raise ValueError
+    except ValueError:
+        await msg.answer("Formato inválido. Usá mm/aaaa, ej: 07/2024")
+        return
+
+    data = await state.get_data()
+    file_path = data.get("file_path")
+    soffice_bin = os.getenv("SOFFICE_BIN")
+    paths = run(file_path, mes, anio, soffice_bin)
+
+    await msg.answer_document(FSInputFile(paths["docx"]))
+    if paths.get("pdf"):
+        await msg.answer_document(FSInputFile(paths["pdf"]))
+
+    logger.info(
+        "service=bot flow=repetitividad tg_user_id=%s file=%s periodo=%02d/%04d",
+        msg.from_user.id,
+        Path(file_path).name,
+        mes,
+        anio,
+    )
+    await state.clear()
+
+
+@router.message(RepetitividadStates.WAITING_PERIOD)
+async def on_invalid_period(msg: Message) -> None:
+    await msg.answer("Debés ingresar el período en formato mm/aaaa o /cancel")
+
+
+@router.message(Command("cancel"))
+async def on_cancel(msg: Message, state: FSMContext) -> None:
+    """Cancela cualquier estado activo del flujo."""
+    if await state.get_state() is not None:
+        await state.clear()
+        await msg.answer("Operación cancelada")
+

--- a/bot_telegram/handlers/basic.py
+++ b/bot_telegram/handlers/basic.py
@@ -5,12 +5,18 @@
 from aiogram import Router
 from aiogram.types import Message
 
+from bot_telegram.ui.reply_keyboard import get_main_reply_keyboard
+
 router = Router()
 
 
 @router.message(commands={"start"})
 async def cmd_start(msg: Message):
-    await msg.answer("🦭 ¡Hola! Soy el bot de LAS-FOCAS. Probá /ping o /help.")
+    """Mensaje de bienvenida opcional mostrando el teclado de atajos."""
+    await msg.answer(
+        "🦭 ¡Hola! Soy el bot de LAS-FOCAS. Probá /ping o /help.",
+        reply_markup=get_main_reply_keyboard(),
+    )
 
 
 @router.message(commands={"help"})

--- a/bot_telegram/handlers/commands.py
+++ b/bot_telegram/handlers/commands.py
@@ -5,11 +5,16 @@
 import logging
 from aiogram import Router
 from aiogram.filters import Command
+from aiogram.fsm.context import FSMContext
 from aiogram.types import Message
 
 from bot_telegram.diag.counters import inc, snapshot
 from bot_telegram.flows.repetitividad import start_repetitividad_flow
 from bot_telegram.flows.sla import start_sla_flow
+from bot_telegram.ui.reply_keyboard import (
+    get_hide_keyboard,
+    get_main_reply_keyboard,
+)
 
 router = Router()
 logger = logging.getLogger(__name__)
@@ -28,7 +33,7 @@ async def cmd_sla(message: Message) -> None:
 
 
 @router.message(Command("repetitividad"))
-async def cmd_repetitividad(message: Message) -> None:
+async def cmd_repetitividad(message: Message, state: FSMContext) -> None:
     """Inicia el flujo de Repetitividad desde el comando /repetitividad."""
     tg_user_id = message.from_user.id
     logger.info(
@@ -36,7 +41,21 @@ async def cmd_repetitividad(message: Message) -> None:
         tg_user_id,
     )
     inc("commands_rep")
-    await start_repetitividad_flow(message, origin="command")
+    await start_repetitividad_flow(message, state, origin="command")
+
+
+@router.message(Command("keyboard"))
+async def cmd_keyboard(message: Message) -> None:
+    """Muestra el ReplyKeyboard principal."""
+    await message.answer(
+        "Atajos habilitados", reply_markup=get_main_reply_keyboard()
+    )
+
+
+@router.message(Command("hide"))
+async def cmd_hide(message: Message) -> None:
+    """Oculta el ReplyKeyboard del chat."""
+    await message.answer("Teclado oculto", reply_markup=get_hide_keyboard())
 
 
 @router.message(Command("diag"))

--- a/bot_telegram/handlers/menu.py
+++ b/bot_telegram/handlers/menu.py
@@ -5,6 +5,7 @@
 import logging
 
 from aiogram import F, Router
+from aiogram.fsm.context import FSMContext
 from aiogram.types import CallbackQuery, Message
 
 from bot_telegram.diag.counters import inc
@@ -40,7 +41,7 @@ async def on_menu_sla(cb: CallbackQuery) -> None:
 
 
 @router.callback_query(F.data == "menu_repetitividad")
-async def on_menu_repetitividad(cb: CallbackQuery) -> None:
+async def on_menu_repetitividad(cb: CallbackQuery, state: FSMContext) -> None:
     """Gestiona la opción del menú para Repetitividad."""
     tg_user_id = cb.from_user.id
     logger.info(
@@ -49,7 +50,7 @@ async def on_menu_repetitividad(cb: CallbackQuery) -> None:
     )
     inc("callbacks_rep")
     await cb.answer()
-    await start_repetitividad_flow(cb.message, origin="callback")
+    await start_repetitividad_flow(cb.message, state, origin="callback")
 
 
 @router.callback_query(F.data == "menu_close")

--- a/bot_telegram/requirements.txt
+++ b/bot_telegram/requirements.txt
@@ -3,3 +3,6 @@
 # Descripción: Dependencias específicas del bot de Telegram
 
 aiogram==3.13.1
+pandas==2.2.2
+openpyxl==3.1.2
+python-docx==0.8.11

--- a/bot_telegram/ui/reply_keyboard.py
+++ b/bot_telegram/ui/reply_keyboard.py
@@ -1,0 +1,19 @@
+# Nombre de archivo: reply_keyboard.py
+# Ubicación de archivo: bot_telegram/ui/reply_keyboard.py
+# Descripción: Constructores de ReplyKeyboard con atajos de comandos
+
+from aiogram.types import KeyboardButton, ReplyKeyboardMarkup, ReplyKeyboardRemove
+
+
+def get_main_reply_keyboard() -> ReplyKeyboardMarkup:
+    """Teclado principal con atajos de comandos."""
+    keyboard = [
+        [KeyboardButton(text="/sla"), KeyboardButton(text="/repetitividad")],
+        [KeyboardButton(text="/menu"), KeyboardButton(text="/hide")],
+    ]
+    return ReplyKeyboardMarkup(keyboard=keyboard, resize_keyboard=True)
+
+
+def get_hide_keyboard() -> ReplyKeyboardRemove:
+    """Oculta el ReplyKeyboard."""
+    return ReplyKeyboardRemove()

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -72,6 +72,8 @@ services:
     depends_on:
       - api
     restart: unless-stopped
+    volumes:
+      - bot_data:/app/data
 
   # (Opcional) pgAdmin. Levantar con: docker compose -f deploy/compose.yml --profile pgadmin up -d
   pgadmin:
@@ -91,6 +93,7 @@ services:
 
 volumes:
   postgres_data:
+  bot_data:
 
 networks:
   lasfocas_net:

--- a/deploy/env.sample
+++ b/deploy/env.sample
@@ -20,3 +20,6 @@ OLLAMA_URL=http://ollama:11434
 INTENT_THRESHOLD=0.7
 LANG=es
 LOG_RAW_TEXT=false
+
+# LibreOffice
+SOFFICE_BIN=/usr/bin/soffice

--- a/docs/bot.md
+++ b/docs/bot.md
@@ -35,7 +35,7 @@ Botones disponibles:
 - 📊 Informe de Repetitividad
 - ❌ Cerrar
 
-Actualmente, cada opción responde “implementación pendiente” y deja listo el hook para integrar el flujo real.
+Actualmente, el flujo de **Repetitividad** está operativo mientras que **SLA** continúa en desarrollo.
 
 Ejemplos de frases que abren el menú por intención:
 
@@ -88,6 +88,10 @@ Ejemplos:
 
 - `/sla` y botón **📈 Análisis de SLA** comparten `start_sla_flow`.
 - `/repetitividad` y botón **📊 Informe de Repetitividad** comparten `start_repetitividad_flow`.
+
+### ReplyKeyboard
+El comando `/keyboard` muestra un teclado con atajos (`/sla`, `/repetitividad`, `/menu`, `/hide`).
+El comando `/hide` lo oculta.
 
 Para un diagnóstico rápido está disponible `/diag`, que muestra los contadores de invocaciones recibidas:
 

--- a/docs/informes/repetitividad.md
+++ b/docs/informes/repetitividad.md
@@ -1,0 +1,26 @@
+# Nombre de archivo: repetitividad.md
+# Ubicación de archivo: docs/informes/repetitividad.md
+# Descripción: Documentación del informe de Repetitividad
+
+## Insumos requeridos
+- Excel "Casos" en formato `.xlsx`.
+- Columnas mínimas: `CLIENTE`, `SERVICIO`, `FECHA` y opcional `ID_SERVICIO`.
+- Los datos del cliente **BANCO MACRO SA** nunca se filtran automáticamente.
+
+## Cálculo
+- Se normalizan las columnas y se genera `PERIODO = YYYY-MM`.
+- Se filtra por período indicado (mes/año).
+- Se agrupan casos por `SERVICIO` y se consideran repetitivos aquellos con **2 o más** casos.
+- Se genera una tabla con servicio, cantidad y detalles/IDs.
+
+## Uso por Telegram
+1. Enviar comando `/repetitividad` o usar el botón correspondiente.
+2. Subir el Excel.
+3. Indicar el período `mm/aaaa`.
+4. El bot devuelve un archivo `.docx` y opcionalmente `.pdf`.
+
+## Paths de salida
+- Archivos generados en `/app/data/reports/` dentro del contenedor del bot.
+
+## Variables de entorno
+- `SOFFICE_BIN=/usr/bin/soffice` para habilitar la conversión a PDF (opcional).

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,0 +1,4 @@
+# Nombre de archivo: __init__.py
+# Ubicación de archivo: modules/__init__.py
+# Descripción: Inicializa el paquete de módulos de la aplicación
+

--- a/modules/informes_repetitividad/__init__.py
+++ b/modules/informes_repetitividad/__init__.py
@@ -1,0 +1,4 @@
+# Nombre de archivo: __init__.py
+# Ubicación de archivo: modules/informes_repetitividad/__init__.py
+# Descripción: Inicializa el paquete de informes de repetitividad
+

--- a/modules/informes_repetitividad/config.py
+++ b/modules/informes_repetitividad/config.py
@@ -1,0 +1,44 @@
+# Nombre de archivo: config.py
+# Ubicación de archivo: modules/informes_repetitividad/config.py
+# Descripción: Configuración y constantes para el informe de repetitividad
+
+from pathlib import Path
+from typing import Dict, List
+
+# Mapeo de columnas esperadas en el Excel de casos
+COLUMNAS_MAPPER: Dict[str, str] = {
+    "CLIENTE": "CLIENTE",
+    "SERVICIO": "SERVICIO",
+    "ID_SERVICIO": "ID_SERVICIO",
+    "FECHA": "FECHA",
+}
+
+# Columnas obligatorias para procesar el informe
+COLUMNAS_OBLIGATORIAS: List[str] = [
+    "CLIENTE",
+    "SERVICIO",
+    "FECHA",
+]
+
+# Clientes que nunca deben ser excluidos por filtros
+CLIENTES_PRESERVAR: List[str] = ["BANCO MACRO SA"]
+
+# Lista de meses en español para formatear encabezados
+MESES_ES: List[str] = [
+    "enero",
+    "febrero",
+    "marzo",
+    "abril",
+    "mayo",
+    "junio",
+    "julio",
+    "agosto",
+    "septiembre",
+    "octubre",
+    "noviembre",
+    "diciembre",
+]
+
+# Directorios base de trabajo dentro del contenedor del bot
+BASE_UPLOADS = Path("/app/data/uploads")
+BASE_REPORTS = Path("/app/data/reports")

--- a/modules/informes_repetitividad/processor.py
+++ b/modules/informes_repetitividad/processor.py
@@ -1,0 +1,86 @@
+# Nombre de archivo: processor.py
+# Ubicación de archivo: modules/informes_repetitividad/processor.py
+# Descripción: Funciones de carga, normalización y cálculo de repetitividad
+
+import logging
+from typing import Optional
+
+import pandas as pd
+
+from .config import (
+    CLIENTES_PRESERVAR,
+    COLUMNAS_MAPPER,
+    COLUMNAS_OBLIGATORIAS,
+)
+from .schemas import ItemSalida, ResultadoRepetitividad
+
+logger = logging.getLogger(__name__)
+
+
+def load_excel(path: str) -> pd.DataFrame:
+    """Carga un archivo Excel en un DataFrame."""
+    try:
+        return pd.read_excel(path, engine="openpyxl")
+    except Exception as exc:  # pragma: no cover - logging
+        logger.exception("action=load_excel error=%s path=%s", exc, path)
+        raise
+
+
+def normalize(df: pd.DataFrame) -> pd.DataFrame:
+    """Normaliza nombres de columnas y formatos de fecha."""
+    df = df.rename(columns={k: v for k, v in COLUMNAS_MAPPER.items() if k in df.columns})
+    df.columns = [c.upper() for c in df.columns]
+
+    missing = [c for c in COLUMNAS_OBLIGATORIAS if c not in df.columns]
+    if missing:
+        raise ValueError(f"Faltan columnas requeridas: {', '.join(missing)}")
+
+    df["CLIENTE"] = df["CLIENTE"].astype(str).str.upper()
+    df["SERVICIO"] = df["SERVICIO"].astype(str).str.strip()
+
+    # Eliminamos filas con datos faltantes, preservando clientes críticos
+    df = df[df["CLIENTE"].notna() | df["CLIENTE"].isin(CLIENTES_PRESERVAR)]
+
+    df["FECHA"] = pd.to_datetime(df["FECHA"], errors="coerce")
+    df = df.dropna(subset=["FECHA", "SERVICIO"])
+
+    df["PERIODO"] = df["FECHA"].dt.strftime("%Y-%m")
+    return df
+
+
+def filter_period(df: pd.DataFrame, mes: int, anio: int) -> pd.DataFrame:
+    """Filtra el DataFrame por un período específico."""
+    periodo = f"{anio:04d}-{mes:02d}"
+    filtrado = df[df["PERIODO"] == periodo]
+    return filtrado
+
+
+def _detalles(grupo: pd.DataFrame) -> list[str]:
+    if "ID_SERVICIO" in grupo.columns and grupo["ID_SERVICIO"].notna().any():
+        return grupo["ID_SERVICIO"].astype(str).tolist()
+    return grupo.index.astype(str).tolist()
+
+
+def compute_repetitividad(df: pd.DataFrame) -> ResultadoRepetitividad:
+    """Calcula servicios con casos repetidos (>=2 en el período)."""
+    total_servicios = df["SERVICIO"].nunique()
+    items: list[ItemSalida] = []
+
+    for servicio, grupo in df.groupby("SERVICIO"):
+        conteo = len(grupo)
+        if conteo >= 2:
+            items.append(
+                ItemSalida(servicio=servicio, casos=conteo, detalles=_detalles(grupo))
+            )
+
+    resultado = ResultadoRepetitividad(
+        items=items,
+        total_servicios=total_servicios,
+        total_repetitivos=len(items),
+    )
+    logger.info(
+        "action=compute_repetitividad total_servicios=%s total_repetitivos=%s",
+        total_servicios,
+        len(items),
+    )
+    return resultado

--- a/modules/informes_repetitividad/report.py
+++ b/modules/informes_repetitividad/report.py
@@ -1,0 +1,94 @@
+# Nombre de archivo: report.py
+# Ubicación de archivo: modules/informes_repetitividad/report.py
+# Descripción: Generación de archivos DOCX y PDF para el informe de repetitividad
+
+import logging
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+from docx import Document
+from docx.enum.text import WD_ALIGN_PARAGRAPH
+from docx.oxml import OxmlElement
+from docx.oxml.ns import qn
+
+from .config import MESES_ES
+from .schemas import Params, ResultadoRepetitividad
+
+logger = logging.getLogger(__name__)
+
+
+def _header_cell(cell, text: str) -> None:
+    cell.text = text
+    shading = OxmlElement("w:shd")
+    shading.set(qn("w:fill"), "D9D9D9")
+    cell._tc.get_or_add_tcPr().append(shading)
+
+
+def export_docx(data: ResultadoRepetitividad, periodo: Params, out_dir: str) -> str:
+    """Genera el archivo DOCX con la tabla de repetitividad."""
+    mes_nombre = MESES_ES[periodo.periodo_mes - 1].capitalize()
+    doc = Document()
+    doc.add_heading(f"Informe de Repetitividad — {mes_nombre} {periodo.periodo_anio}", level=1)
+
+    doc.add_paragraph(
+        f"Servicios analizados: {data.total_servicios} | Servicios con repetitividad: {data.total_repetitivos}",
+    )
+
+    table = doc.add_table(rows=1, cols=3)
+    hdr_cells = table.rows[0].cells
+    _header_cell(hdr_cells[0], "Servicio")
+    _header_cell(hdr_cells[1], "Casos Repetidos")
+    _header_cell(hdr_cells[2], "Detalles/IDs")
+
+    for item in data.items:
+        row = table.add_row().cells
+        row[0].text = item.servicio
+        row[1].text = str(item.casos)
+        row[2].text = ", ".join(item.detalles)
+        if item.casos >= 4:
+            row[1].paragraphs[0].runs[0].bold = True
+
+    for row in table.rows:
+        for cell in row.cells:
+            cell.paragraphs[0].alignment = WD_ALIGN_PARAGRAPH.LEFT
+
+    out_dir_path = Path(out_dir)
+    out_dir_path.mkdir(parents=True, exist_ok=True)
+    docx_path = out_dir_path / f"repetitividad_{periodo.periodo_anio}{periodo.periodo_mes:02d}.docx"
+    doc.save(docx_path)
+    logger.info("action=export_docx path=%s", docx_path)
+    return str(docx_path)
+
+
+def maybe_export_pdf(docx_path: str, out_dir: str, soffice_bin: Optional[str]) -> Optional[str]:
+    """Convierte el DOCX a PDF si LibreOffice está disponible."""
+    if not soffice_bin:
+        return None
+
+    out_dir_path = Path(out_dir)
+    out_dir_path.mkdir(parents=True, exist_ok=True)
+    try:
+        subprocess.run(
+            [
+                soffice_bin,
+                "--headless",
+                "--convert-to",
+                "pdf",
+                docx_path,
+                "--outdir",
+                str(out_dir_path),
+            ],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except Exception as exc:  # pragma: no cover - logging
+        logger.exception("action=maybe_export_pdf error=%s", exc)
+        return None
+
+    pdf_path = Path(out_dir) / (Path(docx_path).stem + ".pdf")
+    if pdf_path.exists():
+        logger.info("action=maybe_export_pdf path=%s", pdf_path)
+        return str(pdf_path)
+    return None

--- a/modules/informes_repetitividad/runner.py
+++ b/modules/informes_repetitividad/runner.py
@@ -1,0 +1,39 @@
+# Nombre de archivo: runner.py
+# Ubicación de archivo: modules/informes_repetitividad/runner.py
+# Descripción: Orquestador del flujo de cálculo y generación de reportes
+
+import logging
+from typing import Dict, Optional
+
+from . import processor, report
+from .config import BASE_REPORTS
+from .schemas import Params
+
+logger = logging.getLogger(__name__)
+
+
+def run(file_path: str, mes: int, anio: int, soffice_bin: Optional[str]) -> Dict[str, str]:
+    """Ejecuta el flujo completo de cálculo y exportación del informe."""
+    df = processor.load_excel(file_path)
+    df = processor.normalize(df)
+    df = processor.filter_period(df, mes, anio)
+    resultado = processor.compute_repetitividad(df)
+
+    params = Params(periodo_mes=mes, periodo_anio=anio)
+    docx_path = report.export_docx(resultado, params, str(BASE_REPORTS))
+    pdf_path = report.maybe_export_pdf(docx_path, str(BASE_REPORTS), soffice_bin)
+
+    logger.info(
+        "action=run mes=%s anio=%s docx=%s pdf=%s total=%s repetitivos=%s",
+        mes,
+        anio,
+        docx_path,
+        pdf_path,
+        resultado.total_servicios,
+        resultado.total_repetitivos,
+    )
+
+    paths = {"docx": docx_path}
+    if pdf_path:
+        paths["pdf"] = pdf_path
+    return paths

--- a/modules/informes_repetitividad/schemas.py
+++ b/modules/informes_repetitividad/schemas.py
@@ -1,0 +1,29 @@
+# Nombre de archivo: schemas.py
+# Ubicación de archivo: modules/informes_repetitividad/schemas.py
+# Descripción: Modelos de datos para el informe de repetitividad
+
+from typing import List
+from pydantic import BaseModel
+
+
+class Params(BaseModel):
+    """Parámetros de período para generar el informe."""
+
+    periodo_mes: int
+    periodo_anio: int
+
+
+class ItemSalida(BaseModel):
+    """Resultado por servicio con casos repetidos."""
+
+    servicio: str
+    casos: int
+    detalles: List[str]
+
+
+class ResultadoRepetitividad(BaseModel):
+    """Resultado completo del cálculo de repetitividad."""
+
+    items: List[ItemSalida]
+    total_servicios: int
+    total_repetitivos: int

--- a/tests/test_flows_builders.py
+++ b/tests/test_flows_builders.py
@@ -2,7 +2,6 @@
 # Ubicación de archivo: tests/test_flows_builders.py
 # Descripción: Pruebas de los builders de respuesta de los flujos del bot
 
-from bot_telegram.flows.repetitividad import build_repetitividad_response
 from bot_telegram.flows.sla import build_sla_response
 
 
@@ -10,11 +9,4 @@ def test_build_sla_response() -> None:
     """Verifica que el builder de SLA contiene el texto esperado."""
     text = build_sla_response()
     assert "📈" in text
-    assert "implementación pendiente" in text
-
-
-def test_build_repetitividad_response() -> None:
-    """Verifica que el builder de Repetitividad contiene el texto esperado."""
-    text = build_repetitividad_response()
-    assert "📊" in text
     assert "implementación pendiente" in text

--- a/tests/test_repetitividad_processor.py
+++ b/tests/test_repetitividad_processor.py
@@ -1,0 +1,24 @@
+# Nombre de archivo: test_repetitividad_processor.py
+# Ubicación de archivo: tests/test_repetitividad_processor.py
+# Descripción: Pruebas del procesamiento de repetitividad
+
+import pandas as pd
+
+from modules.informes_repetitividad import processor
+
+
+def test_compute_repetitividad_preserva_macro():
+    datos = [
+        {"CLIENTE": "BANCO MACRO SA", "SERVICIO": "S1", "FECHA": "2024-07-01", "ID_SERVICIO": "1"},
+        {"CLIENTE": "BANCO MACRO SA", "SERVICIO": "S1", "FECHA": "2024-07-15", "ID_SERVICIO": "2"},
+        {"CLIENTE": "OTRO", "SERVICIO": "S2", "FECHA": "2024-07-20", "ID_SERVICIO": "3"},
+    ]
+    df = pd.DataFrame(datos)
+    df = processor.normalize(df)
+    df = processor.filter_period(df, 7, 2024)
+    res = processor.compute_repetitividad(df)
+
+    assert res.total_servicios == 2
+    assert res.total_repetitivos == 1
+    assert res.items[0].servicio == "S1"
+    assert "BANCO MACRO SA" in df["CLIENTE"].unique()

--- a/tests/test_report_builder.py
+++ b/tests/test_report_builder.py
@@ -1,0 +1,23 @@
+# Nombre de archivo: test_report_builder.py
+# Ubicación de archivo: tests/test_report_builder.py
+# Descripción: Pruebas de generación de reportes DOCX
+
+from pathlib import Path
+
+from docx import Document
+
+from modules.informes_repetitividad.report import export_docx
+from modules.informes_repetitividad.schemas import ItemSalida, Params, ResultadoRepetitividad
+
+
+def test_export_docx_crea_archivo(tmp_path):
+    params = Params(periodo_mes=7, periodo_anio=2024)
+    data = ResultadoRepetitividad(
+        items=[ItemSalida(servicio="S1", casos=2, detalles=["1", "2"])],
+        total_servicios=1,
+        total_repetitivos=1,
+    )
+    path = export_docx(data, params, tmp_path)
+    assert Path(path).exists()
+    doc = Document(path)
+    assert "Julio 2024" in doc.paragraphs[0].text


### PR DESCRIPTION
## Resumen
- Generación de informe de repetitividad con pandas y python-docx, preservando clientes clave y soportando exportación opcional a PDF.
- Flujo de Telegram con FSM para recibir Excel, solicitar período y devolver reportes; ReplyKeyboard de atajos `/sla`, `/repetitividad`, `/menu` y `/hide`.
- Documentación, pruebas unitarias y configuración Docker/ENV actualizadas para el nuevo flujo.

## Pruebas
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7572c79748330949a9e9a8aa4568d