### PR TITLE
[sla] Implementar flujo de análisis de SLA

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,7 @@ Todos los prompts deben seguir este esquema **en este orden**:
 
 * Actualizar **README**, **AGENTS.md** y **requirements** cuando corresponda.
 * En `/docs/` crear/actualizar la documentación específica del módulo tocado (ej.: `docs/bot.md`, `docs/nlp/intent.md`, `docs/db.md`).
+* `docs/informes/sla.md` documenta el informe de SLA y debe mantenerse al día.
 * Mantener un registro de decisiones técnicas en `docs/decisiones.md` (formato breve: contexto → decisión → alternativas → impactos).
 
 ### 8) Docker/Infra
@@ -135,6 +136,7 @@ Todos los prompts deben seguir este esquema **en este orden**:
 * **Menú principal**: cuando la intención sea "Acción" y el mensaje contenga palabras clave de menú, abrir el menú principal.
 * **Mensajes de sistema**: ser claros, breves y accionables.
 * **ReplyKeyboard**: disponible con atajos `/sla`, `/repetitividad`, `/menu` y `/hide` como alternativa a callbacks.
+* **Flujo SLA**: operativo; ver `docs/informes/sla.md` para insumos y alcance.
 
 ### 10) Rendimiento y resiliencia
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Automatizaciones operativas para Metrotel: generación de informes, asistente co
 
 - **Interfaces**
 
-  - **Telegram Bot** (primer canal de operación, con menú accesible por `/menu` o por intención). Incluye el flujo `/repetitividad` y un teclado opcional con atajos a `/sla` y `/repetitividad`. Ver [docs/bot.md](docs/bot.md) para guía rápida.
+  - **Telegram Bot** (primer canal de operación, con menú accesible por `/menu` o por intención). Incluye los flujos `/repetitividad` y `/sla` y un teclado opcional con atajos a ambos comandos. Ver [docs/bot.md](docs/bot.md) para guía rápida.
   - **Web Panel** (autenticación simple, accesible por IP interna .28).
   - **nlp_intent** (microservicio NLP para clasificación de intención).
   - CLI opcional para utilidades.

--- a/bot_telegram/app.py
+++ b/bot_telegram/app.py
@@ -14,6 +14,7 @@ from bot_telegram.filters.allowlist import AllowlistMiddleware
 from bot_telegram.handlers.basic import router as basic_router
 from bot_telegram.handlers.commands import router as commands_router
 from bot_telegram.flows.repetitividad import router as rep_router
+from bot_telegram.flows.sla import router as sla_router
 from bot_telegram.handlers.intent import router as intent_router
 from bot_telegram.handlers.menu import router as menu_router
 
@@ -36,6 +37,7 @@ async def main():
     dp.callback_query.middleware(allowlist)
 
     # Routers
+    dp.include_router(sla_router)
     dp.include_router(rep_router)
     dp.include_router(menu_router)
     dp.include_router(commands_router)

--- a/bot_telegram/flows/sla.py
+++ b/bot_telegram/flows/sla.py
@@ -1,24 +1,119 @@
 # Nombre de archivo: sla.py
 # Ubicación de archivo: bot_telegram/flows/sla.py
-# Descripción: Flujo unificado para el análisis de SLA del bot
+# Descripción: Flujo para recibir Excel y generar el informe de SLA
 
 import logging
-from aiogram.types import Message
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
 
+from aiogram import F, Router
+from aiogram.filters import Command
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.state import State, StatesGroup
+from aiogram.types import FSInputFile, Message
+
+from modules.informes_sla.config import BASE_UPLOADS
+from modules.informes_sla.runner import run
+
+router = Router()
 logger = logging.getLogger(__name__)
 
 
+class SLAStates(StatesGroup):
+    WAITING_FILE = State()
+    WAITING_PERIOD = State()
+
+
 def build_sla_response() -> str:
-    """Genera el texto base para el análisis de SLA."""
-    return "📈 Análisis de SLA — implementación pendiente"
+    """Mensaje inicial solicitando el Excel."""
+    return "📈 Enviá el Excel 'Casos' en formato .xlsx o /cancel para salir"
 
 
-async def start_sla_flow(msg: Message, origin: str) -> None:
-    """Inicia el flujo de SLA enviando el mensaje estándar."""
+async def start_sla_flow(msg: Message, state: FSMContext, origin: str) -> None:
+    """Inicia el flujo de SLA solicitando el archivo."""
     tg_user_id = msg.from_user.id
     logger.info(
         "service=bot route=%s action=start_sla_flow tg_user_id=%s",
         origin,
         tg_user_id,
     )
+    await state.clear()
     await msg.answer(build_sla_response())
+    await state.set_state(SLAStates.WAITING_FILE)
+
+
+@router.message(SLAStates.WAITING_FILE, F.document)
+async def on_file(msg: Message, state: FSMContext) -> None:
+    """Recibe y almacena el Excel enviado por el usuario."""
+    document = msg.document
+    if not document.file_name.lower().endswith(".xlsx"):
+        await msg.answer("El archivo debe tener extensión .xlsx. Intentá nuevamente")
+        return
+
+    user_dir = BASE_UPLOADS / "telegram" / str(msg.from_user.id)
+    user_dir.mkdir(parents=True, exist_ok=True)
+    file_path = user_dir / document.file_name
+    await document.download(destination=file_path)
+    await state.update_data(file_path=str(file_path))
+
+    prev_month = datetime.now().replace(day=1) - timedelta(days=1)
+    sugerencia = prev_month.strftime("%m/%Y")
+    await msg.answer(f"Ingresá el período a analizar (mm/aaaa). Ejemplo: {sugerencia}")
+    await state.set_state(SLAStates.WAITING_PERIOD)
+
+
+@router.message(SLAStates.WAITING_FILE)
+async def on_invalid_file(msg: Message) -> None:
+    await msg.answer("Necesito un archivo .xlsx válido o /cancel para salir")
+
+
+@router.message(SLAStates.WAITING_PERIOD, F.text)
+async def on_period(msg: Message, state: FSMContext) -> None:
+    """Procesa el período y genera el informe."""
+    texto = msg.text.strip()
+    try:
+        mes, anio = map(int, texto.split("/"))
+        if not (1 <= mes <= 12 and anio >= 2000):
+            raise ValueError
+    except ValueError:
+        await msg.answer("Formato inválido. Usá mm/aaaa, ej: 07/2024")
+        return
+
+    data = await state.get_data()
+    file_path = data.get("file_path")
+    soffice_bin = os.getenv("SOFFICE_BIN")
+    resultado = run(file_path, mes, anio, soffice_bin)
+
+    await msg.answer_document(FSInputFile(resultado["docx"]))
+    if resultado.get("pdf"):
+        await msg.answer_document(FSInputFile(resultado["pdf"]))
+    if resultado["resultado"].sin_cierre:
+        await msg.answer(
+            f"Se excluyeron {resultado['resultado'].sin_cierre} casos sin fecha de cierre"
+        )
+
+    logger.info(
+        "service=bot flow=sla tg_user_id=%s file=%s periodo=%02d/%04d pct_cumplimiento=%.2f total=%s incumplidos=%s",  # noqa: E501
+        msg.from_user.id,
+        Path(file_path).name,
+        mes,
+        anio,
+        resultado["resultado"].kpi.pct_cumplimiento,
+        resultado["resultado"].kpi.total,
+        resultado["resultado"].kpi.incumplidos,
+    )
+    await state.clear()
+
+
+@router.message(SLAStates.WAITING_PERIOD)
+async def on_invalid_period(msg: Message) -> None:
+    await msg.answer("Debés ingresar el período en formato mm/aaaa o /cancel")
+
+
+@router.message(Command("cancel"))
+async def on_cancel(msg: Message, state: FSMContext) -> None:
+    """Cancela el flujo activo de SLA."""
+    if await state.get_state() is not None:
+        await state.clear()
+        await msg.answer("Operación cancelada")

--- a/bot_telegram/handlers/commands.py
+++ b/bot_telegram/handlers/commands.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 @router.message(Command("sla"))
-async def cmd_sla(message: Message) -> None:
+async def cmd_sla(message: Message, state: FSMContext) -> None:
     """Inicia el flujo de SLA desde el comando /sla."""
     tg_user_id = message.from_user.id
     logger.info(
@@ -29,7 +29,7 @@ async def cmd_sla(message: Message) -> None:
         tg_user_id,
     )
     inc("commands_sla")
-    await start_sla_flow(message, origin="command")
+    await start_sla_flow(message, state, origin="command")
 
 
 @router.message(Command("repetitividad"))

--- a/bot_telegram/handlers/menu.py
+++ b/bot_telegram/handlers/menu.py
@@ -28,7 +28,7 @@ async def cmd_menu(msg: Message) -> None:
 
 
 @router.callback_query(F.data == "menu_sla")
-async def on_menu_sla(cb: CallbackQuery) -> None:
+async def on_menu_sla(cb: CallbackQuery, state: FSMContext) -> None:
     """Gestiona la opción del menú para SLA."""
     tg_user_id = cb.from_user.id
     logger.info(
@@ -37,7 +37,7 @@ async def on_menu_sla(cb: CallbackQuery) -> None:
     )
     inc("callbacks_sla")
     await cb.answer()
-    await start_sla_flow(cb.message, origin="callback")
+    await start_sla_flow(cb.message, state, origin="callback")
 
 
 @router.callback_query(F.data == "menu_repetitividad")

--- a/docs/bot.md
+++ b/docs/bot.md
@@ -35,7 +35,7 @@ Botones disponibles:
 - 📊 Informe de Repetitividad
 - ❌ Cerrar
 
-Actualmente, el flujo de **Repetitividad** está operativo mientras que **SLA** continúa en desarrollo.
+Los flujos de **Repetitividad** y **SLA** están operativos.
 
 Ejemplos de frases que abren el menú por intención:
 

--- a/docs/informes/sla.md
+++ b/docs/informes/sla.md
@@ -1,0 +1,40 @@
+# Nombre de archivo: sla.md
+# Ubicación de archivo: docs/informes/sla.md
+# Descripción: Documentación del informe de SLA
+
+## Columnas esperadas y mapeos
+- `ID`
+- `CLIENTE`
+- `SERVICIO`
+- `FECHA_APERTURA`
+- `FECHA_CIERRE`
+- `SLA_OBJETIVO_HORAS` (opcional)
+
+Mapeos admitidos: `TicketID`→`ID`, `Apertura`→`FECHA_APERTURA`, `Cierre`→`FECHA_CIERRE`, `SLA`→`SLA_OBJETIVO_HORAS`.
+
+## Cálculo
+- Se normalizan las columnas y se calcula `TTR_h = (FECHA_CIERRE - FECHA_APERTURA) / 3600`.
+- Se filtra por `FECHA_CIERRE` dentro del período indicado (mes/año).
+- Si falta `SLA_OBJETIVO_HORAS`, se usa `SLA_POR_SERVICIO` con fallback **24 h**.
+- Se excluyen casos sin fecha de cierre y se informa la cantidad excluida.
+- Cumplido cuando `TTR_h <= SLA_OBJETIVO_HORAS`.
+
+## Parámetros del período
+- Formato `mm/aaaa`.
+- Mes 1–12, año ≥ 2000.
+
+## Uso por Telegram
+1. Enviar comando `/sla` o usar el botón correspondiente.
+2. Subir el Excel `.xlsx`.
+3. Indicar el período `mm/aaaa`.
+4. El bot devuelve un `.docx` y opcionalmente `.pdf`.
+
+## Límites y notas
+- Se muestran hasta 2000 filas en el detalle.
+- Horas calendario (horario laboral pendiente).
+
+## Paths de salida
+- Archivos en `/app/data/reports/` dentro del contenedor.
+
+## Variables de entorno
+- `SOFFICE_BIN=/usr/bin/soffice` para habilitar PDF (opcional).

--- a/modules/informes_sla/__init__.py
+++ b/modules/informes_sla/__init__.py
@@ -1,0 +1,4 @@
+# Nombre de archivo: __init__.py
+# Ubicación de archivo: modules/informes_sla/__init__.py
+# Descripción: Inicializa el paquete de informes de SLA
+

--- a/modules/informes_sla/config.py
+++ b/modules/informes_sla/config.py
@@ -1,0 +1,59 @@
+# Nombre de archivo: config.py
+# Ubicación de archivo: modules/informes_sla/config.py
+# Descripción: Configuración y constantes para el informe de SLA
+
+from pathlib import Path
+from typing import Dict, List
+
+# Mapeo de nombres de columnas crudas a nombres canónicos
+COLUMNAS_MAPPER: Dict[str, str] = {
+    "TicketID": "ID",
+    "ID_TICKET": "ID",
+    "Cliente": "CLIENTE",
+    "CLIENTE": "CLIENTE",
+    "Servicio": "SERVICIO",
+    "SERVICIO": "SERVICIO",
+    "Apertura": "FECHA_APERTURA",
+    "Fecha Apertura": "FECHA_APERTURA",
+    "FECHA_APERTURA": "FECHA_APERTURA",
+    "Cierre": "FECHA_CIERRE",
+    "Fecha Cierre": "FECHA_CIERRE",
+    "FECHA_CIERRE": "FECHA_CIERRE",
+    "SLA": "SLA_OBJETIVO_HORAS",
+    "SLA_OBJETIVO_HORAS": "SLA_OBJETIVO_HORAS",
+}
+
+# Columnas obligatorias para el cálculo del SLA
+COLUMNAS_OBLIGATORIAS: List[str] = [
+    "ID",
+    "CLIENTE",
+    "SERVICIO",
+    "FECHA_APERTURA",
+    "FECHA_CIERRE",
+]
+
+# Valores de SLA objetivo por servicio
+SLA_POR_SERVICIO: Dict[str, float] = {
+    "Default": 24.0,
+    "VIP": 12.0,
+}
+
+# Lista de meses en español para encabezados
+MESES_ES: List[str] = [
+    "enero",
+    "febrero",
+    "marzo",
+    "abril",
+    "mayo",
+    "junio",
+    "julio",
+    "agosto",
+    "septiembre",
+    "octubre",
+    "noviembre",
+    "diciembre",
+]
+
+# Directorios de trabajo dentro del contenedor del bot
+BASE_UPLOADS = Path("/app/data/uploads")
+BASE_REPORTS = Path("/app/data/reports")

--- a/modules/informes_sla/processor.py
+++ b/modules/informes_sla/processor.py
@@ -1,0 +1,112 @@
+# Nombre de archivo: processor.py
+# Ubicación de archivo: modules/informes_sla/processor.py
+# Descripción: Funciones de procesamiento de datos para el informe de SLA
+
+import pandas as pd
+
+from .config import COLUMNAS_MAPPER, COLUMNAS_OBLIGATORIAS, SLA_POR_SERVICIO
+from .schemas import FilaDetalle, KPI, ResultadoSLA
+
+
+def load_excel(path: str) -> pd.DataFrame:
+    """Carga un archivo Excel en un DataFrame."""
+    return pd.read_excel(path, engine="openpyxl")
+
+
+def normalize(df: pd.DataFrame) -> pd.DataFrame:
+    """Normaliza nombres de columnas y calcula TTR en horas."""
+    df = df.rename(columns={k: v for k, v in COLUMNAS_MAPPER.items() if k in df.columns})
+
+    faltantes = [c for c in COLUMNAS_OBLIGATORIAS if c not in df.columns]
+    if faltantes:
+        raise ValueError(f"Faltan columnas requeridas: {', '.join(faltantes)}")
+
+    df["FECHA_APERTURA"] = pd.to_datetime(df["FECHA_APERTURA"], errors="coerce")
+    df["FECHA_CIERRE"] = pd.to_datetime(df["FECHA_CIERRE"], errors="coerce")
+    df["TTR_h"] = (df["FECHA_CIERRE"] - df["FECHA_APERTURA"]).dt.total_seconds() / 3600
+    return df
+
+
+def filter_period(df: pd.DataFrame, mes: int, anio: int) -> pd.DataFrame:
+    """Filtra los casos cuyo cierre pertenece al período indicado.
+
+    También preserva los casos abiertos cuyo mes/año de apertura coinciden
+    con el período para poder reportarlos como excluidos.
+    """
+    mask_cierre = (df["FECHA_CIERRE"].dt.month == mes) & (
+        df["FECHA_CIERRE"].dt.year == anio
+    )
+    mask_abiertos = df["FECHA_CIERRE"].isna() & (
+        (df["FECHA_APERTURA"].dt.month == mes)
+        & (df["FECHA_APERTURA"].dt.year == anio)
+    )
+    return df[mask_cierre | mask_abiertos]
+
+
+def apply_sla_target(df: pd.DataFrame) -> pd.DataFrame:
+    """Aplica la columna de SLA objetivo en horas."""
+    if "SLA_OBJETIVO_HORAS" not in df.columns:
+        df["SLA_OBJETIVO_HORAS"] = df["SERVICIO"].map(SLA_POR_SERVICIO).fillna(
+            SLA_POR_SERVICIO.get("Default", 24.0)
+        )
+    else:
+        df["SLA_OBJETIVO_HORAS"] = df["SLA_OBJETIVO_HORAS"].fillna(
+            df["SERVICIO"].map(SLA_POR_SERVICIO)
+        )
+        df["SLA_OBJETIVO_HORAS"].fillna(SLA_POR_SERVICIO.get("Default", 24.0), inplace=True)
+    return df
+
+
+def compute_kpis(df: pd.DataFrame) -> ResultadoSLA:
+    """Calcula KPIs globales y por servicio."""
+    df_valido = df.dropna(subset=["FECHA_CIERRE"]).copy()
+    sin_cierre = len(df) - len(df_valido)
+
+    df_valido["cumplido"] = df_valido["TTR_h"] <= df_valido["SLA_OBJETIVO_HORAS"]
+
+    total = len(df_valido)
+    cumplidos = int(df_valido["cumplido"].sum())
+    incumplidos = total - cumplidos
+    pct = (cumplidos / total * 100) if total else 0.0
+    prom = float(df_valido["TTR_h"].mean()) if total else 0.0
+    med = float(df_valido["TTR_h"].median()) if total else 0.0
+
+    detalle = [
+        FilaDetalle(
+            id=str(row["ID"]),
+            cliente=row["CLIENTE"],
+            servicio=row["SERVICIO"],
+            ttr_h=float(row["TTR_h"]),
+            sla_objetivo_h=float(row["SLA_OBJETIVO_HORAS"]),
+            cumplido=bool(row["cumplido"]),
+        )
+        for _, row in df_valido.iterrows()
+    ]
+
+    breakdown = {}
+    for servicio, grupo in df_valido.groupby("SERVICIO"):
+        total_s = len(grupo)
+        cumplidos_s = int(grupo["cumplido"].sum())
+        incumplidos_s = total_s - cumplidos_s
+        pct_s = (cumplidos_s / total_s * 100) if total_s else 0.0
+        prom_s = float(grupo["TTR_h"].mean()) if total_s else 0.0
+        med_s = float(grupo["TTR_h"].median()) if total_s else 0.0
+        breakdown[servicio] = KPI(
+            total=total_s,
+            cumplidos=cumplidos_s,
+            incumplidos=incumplidos_s,
+            pct_cumplimiento=pct_s,
+            ttr_promedio_h=prom_s,
+            ttr_mediana_h=med_s,
+        )
+
+    kpi_global = KPI(
+        total=total,
+        cumplidos=cumplidos,
+        incumplidos=incumplidos,
+        pct_cumplimiento=pct,
+        ttr_promedio_h=prom,
+        ttr_mediana_h=med,
+    )
+
+    return ResultadoSLA(kpi=kpi_global, detalle=detalle, breakdown_por_servicio=breakdown, sin_cierre=sin_cierre)

--- a/modules/informes_sla/report.py
+++ b/modules/informes_sla/report.py
@@ -1,0 +1,133 @@
+# Nombre de archivo: report.py
+# Ubicación de archivo: modules/informes_sla/report.py
+# Descripción: Generación de archivos DOCX y PDF para el informe de SLA
+
+import logging
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+from docx import Document
+from docx.enum.text import WD_ALIGN_PARAGRAPH
+from docx.oxml import OxmlElement
+from docx.oxml.ns import qn
+
+from .config import MESES_ES
+from .schemas import Params, ResultadoSLA
+
+logger = logging.getLogger(__name__)
+
+
+def _header_cell(cell, text: str) -> None:
+    cell.text = text
+    shading = OxmlElement("w:shd")
+    shading.set(qn("w:fill"), "D9D9D9")
+    cell._tc.get_or_add_tcPr().append(shading)
+
+
+def export_docx(data: ResultadoSLA, periodo: Params, out_dir: str) -> str:
+    """Genera el documento DOCX con el análisis de SLA."""
+    mes_nombre = MESES_ES[periodo.periodo_mes - 1].capitalize()
+    doc = Document()
+    doc.add_heading(f"Análisis de SLA — {mes_nombre} {periodo.periodo_anio}", level=1)
+
+    kpi = data.kpi
+    doc.add_paragraph(
+        " | ".join(
+            [
+                f"Total: {kpi.total}",
+                f"Cumplidos: {kpi.cumplidos}",
+                f"Incumplidos: {kpi.incumplidos}",
+                f"% Cumplimiento: {kpi.pct_cumplimiento:.2f}",
+                f"TTR Promedio (h): {kpi.ttr_promedio_h:.2f}",
+                f"TTR Mediana (h): {kpi.ttr_mediana_h:.2f}",
+            ]
+        )
+    )
+    if data.sin_cierre:
+        doc.add_paragraph(f"Casos sin cierre excluidos: {data.sin_cierre}")
+
+    tabla = doc.add_table(rows=1, cols=6)
+    hdr = tabla.rows[0].cells
+    _header_cell(hdr[0], "ID")
+    _header_cell(hdr[1], "Cliente")
+    _header_cell(hdr[2], "Servicio")
+    _header_cell(hdr[3], "TTR (h)")
+    _header_cell(hdr[4], "SLA Obj (h)")
+    _header_cell(hdr[5], "Cumplido")
+
+    for item in data.detalle[:2000]:
+        row = tabla.add_row().cells
+        row[0].text = item.id
+        row[1].text = item.cliente
+        row[2].text = item.servicio
+        row[3].text = f"{item.ttr_h:.2f}"
+        row[4].text = f"{item.sla_objetivo_h:.2f}"
+        row[5].text = "Sí" if item.cumplido else "No"
+        if not item.cumplido:
+            row[5].paragraphs[0].runs[0].bold = True
+        for cell in row:
+            cell.paragraphs[0].alignment = WD_ALIGN_PARAGRAPH.LEFT
+
+    if data.breakdown_por_servicio:
+        doc.add_paragraph("")
+        tabla_srv = doc.add_table(rows=1, cols=7)
+        hdr2 = tabla_srv.rows[0].cells
+        _header_cell(hdr2[0], "Servicio")
+        _header_cell(hdr2[1], "Total")
+        _header_cell(hdr2[2], "Cumplidos")
+        _header_cell(hdr2[3], "Incumplidos")
+        _header_cell(hdr2[4], "% Cumpl.")
+        _header_cell(hdr2[5], "TTR Prom.")
+        _header_cell(hdr2[6], "TTR Med.")
+        for servicio, kpi_s in data.breakdown_por_servicio.items():
+            row = tabla_srv.add_row().cells
+            row[0].text = servicio
+            row[1].text = str(kpi_s.total)
+            row[2].text = str(kpi_s.cumplidos)
+            row[3].text = str(kpi_s.incumplidos)
+            row[4].text = f"{kpi_s.pct_cumplimiento:.2f}"
+            row[5].text = f"{kpi_s.ttr_promedio_h:.2f}"
+            row[6].text = f"{kpi_s.ttr_mediana_h:.2f}"
+            for cell in row:
+                cell.paragraphs[0].alignment = WD_ALIGN_PARAGRAPH.LEFT
+
+    out_path = Path(out_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+    docx_path = out_path / f"sla_{periodo.periodo_anio}{periodo.periodo_mes:02d}.docx"
+    doc.save(docx_path)
+    logger.info("action=export_docx path=%s", docx_path)
+    return str(docx_path)
+
+
+def maybe_export_pdf(docx_path: str, out_dir: str, soffice_bin: Optional[str]) -> Optional[str]:
+    """Convierte el DOCX a PDF si LibreOffice está disponible."""
+    if not soffice_bin:
+        return None
+
+    out_path = Path(out_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+    try:
+        subprocess.run(
+            [
+                soffice_bin,
+                "--headless",
+                "--convert-to",
+                "pdf",
+                docx_path,
+                "--outdir",
+                str(out_path),
+            ],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except Exception as exc:  # pragma: no cover
+        logger.exception("action=maybe_export_pdf error=%s", exc)
+        return None
+
+    pdf_path = out_path / (Path(docx_path).stem + ".pdf")
+    if pdf_path.exists():
+        logger.info("action=maybe_export_pdf path=%s", pdf_path)
+        return str(pdf_path)
+    return None

--- a/modules/informes_sla/runner.py
+++ b/modules/informes_sla/runner.py
@@ -1,0 +1,42 @@
+# Nombre de archivo: runner.py
+# Ubicación de archivo: modules/informes_sla/runner.py
+# Descripción: Orquestador del flujo de cálculo y generación de reportes de SLA
+
+import logging
+from typing import Dict, Optional
+
+from . import processor, report
+from .config import BASE_REPORTS
+from .schemas import Params, ResultadoSLA
+
+logger = logging.getLogger(__name__)
+
+
+def run(file_path: str, mes: int, anio: int, soffice_bin: Optional[str]) -> Dict[str, object]:
+    """Ejecuta el flujo completo de análisis de SLA."""
+    df = processor.load_excel(file_path)
+    df = processor.normalize(df)
+    df = processor.filter_period(df, mes, anio)
+    df = processor.apply_sla_target(df)
+    resultado: ResultadoSLA = processor.compute_kpis(df)
+
+    params = Params(periodo_mes=mes, periodo_anio=anio)
+    docx_path = report.export_docx(resultado, params, str(BASE_REPORTS))
+    pdf_path = report.maybe_export_pdf(docx_path, str(BASE_REPORTS), soffice_bin)
+
+    logger.info(
+        "action=run mes=%s anio=%s docx=%s pdf=%s total=%s incumplidos=%s pct_cumplimiento=%.2f excluidos=%s",
+        mes,
+        anio,
+        docx_path,
+        pdf_path,
+        resultado.kpi.total,
+        resultado.kpi.incumplidos,
+        resultado.kpi.pct_cumplimiento,
+        resultado.sin_cierre,
+    )
+
+    paths: Dict[str, object] = {"docx": docx_path, "resultado": resultado}
+    if pdf_path:
+        paths["pdf"] = pdf_path
+    return paths

--- a/modules/informes_sla/schemas.py
+++ b/modules/informes_sla/schemas.py
@@ -1,0 +1,44 @@
+# Nombre de archivo: schemas.py
+# Ubicación de archivo: modules/informes_sla/schemas.py
+# Descripción: Modelos de datos para el informe de SLA
+
+from typing import Dict, List
+from pydantic import BaseModel
+
+
+class Params(BaseModel):
+    """Parámetros de período para el informe."""
+
+    periodo_mes: int
+    periodo_anio: int
+
+
+class KPI(BaseModel):
+    """Indicadores clave de cumplimiento de SLA."""
+
+    total: int
+    cumplidos: int
+    incumplidos: int
+    pct_cumplimiento: float
+    ttr_promedio_h: float
+    ttr_mediana_h: float
+
+
+class FilaDetalle(BaseModel):
+    """Detalle por ticket o caso analizado."""
+
+    id: str
+    cliente: str
+    servicio: str
+    ttr_h: float
+    sla_objetivo_h: float
+    cumplido: bool
+
+
+class ResultadoSLA(BaseModel):
+    """Resultado global del análisis de SLA."""
+
+    kpi: KPI
+    detalle: List[FilaDetalle]
+    breakdown_por_servicio: Dict[str, KPI]
+    sin_cierre: int

--- a/tests/test_flows_builders.py
+++ b/tests/test_flows_builders.py
@@ -9,4 +9,4 @@ def test_build_sla_response() -> None:
     """Verifica que el builder de SLA contiene el texto esperado."""
     text = build_sla_response()
     assert "📈" in text
-    assert "implementación pendiente" in text
+    assert "Excel" in text

--- a/tests/test_sla_processor.py
+++ b/tests/test_sla_processor.py
@@ -1,0 +1,71 @@
+# Nombre de archivo: test_sla_processor.py
+# Ubicación de archivo: tests/test_sla_processor.py
+# Descripción: Pruebas del procesamiento y KPIs del informe de SLA
+
+import pandas as pd
+
+from modules.informes_sla import processor
+
+
+def test_compute_kpis_sla():
+    datos = [
+        {
+            "ID": "1",
+            "CLIENTE": "A",
+            "SERVICIO": "VIP",
+            "FECHA_APERTURA": "2024-07-01 00:00",
+            "FECHA_CIERRE": "2024-07-01 10:00",
+        },
+        {
+            "ID": "2",
+            "CLIENTE": "B",
+            "SERVICIO": "VIP",
+            "FECHA_APERTURA": "2024-07-02 00:00",
+            "FECHA_CIERRE": "2024-07-03 18:00",
+        },
+        {
+            "ID": "3",
+            "CLIENTE": "C",
+            "SERVICIO": "COMUN",
+            "FECHA_APERTURA": "2024-07-05 00:00",
+            "FECHA_CIERRE": "2024-07-06 00:00",
+        },
+        {
+            "ID": "4",
+            "CLIENTE": "D",
+            "SERVICIO": "COMUN",
+            "FECHA_APERTURA": "2024-07-05 00:00",
+            "FECHA_CIERRE": "2024-07-07 00:00",
+        },
+        {
+            "ID": "5",
+            "CLIENTE": "E",
+            "SERVICIO": "COMUN",
+            "FECHA_APERTURA": "2024-07-10 00:00",
+            "FECHA_CIERRE": None,
+        },
+        {
+            "ID": "6",
+            "CLIENTE": "F",
+            "SERVICIO": "OTRO",
+            "FECHA_APERTURA": "2024-07-15 00:00",
+            "FECHA_CIERRE": "2024-07-15 12:00",
+            "SLA_OBJETIVO_HORAS": 8,
+        },
+    ]
+    df = pd.DataFrame(datos)
+    df = processor.normalize(df)
+    df = processor.filter_period(df, 7, 2024)
+    df = processor.apply_sla_target(df)
+    res = processor.compute_kpis(df)
+
+    assert res.kpi.total == 5
+    assert res.kpi.cumplidos == 2
+    assert res.kpi.incumplidos == 3
+    assert res.sin_cierre == 1
+    assert res.breakdown_por_servicio["VIP"].cumplidos == 1
+
+    detalle = {d.id: d for d in res.detalle}
+    assert abs(detalle["1"].ttr_h - 10) < 0.1
+    assert detalle["2"].sla_objetivo_h == 12.0
+    assert detalle["6"].sla_objetivo_h == 8

--- a/tests/test_sla_report_builder.py
+++ b/tests/test_sla_report_builder.py
@@ -1,0 +1,47 @@
+# Nombre de archivo: test_sla_report_builder.py
+# Ubicación de archivo: tests/test_sla_report_builder.py
+# Descripción: Pruebas de generación de reportes DOCX para SLA
+
+from pathlib import Path
+
+from docx import Document
+
+from modules.informes_sla.report import export_docx
+from modules.informes_sla.schemas import (
+    FilaDetalle,
+    KPI,
+    Params,
+    ResultadoSLA,
+)
+
+
+def test_export_docx_crea_archivo(tmp_path):
+    params = Params(periodo_mes=7, periodo_anio=2024)
+    kpi = KPI(
+        total=1,
+        cumplidos=1,
+        incumplidos=0,
+        pct_cumplimiento=100.0,
+        ttr_promedio_h=5.0,
+        ttr_mediana_h=5.0,
+    )
+    detalle = [
+        FilaDetalle(
+            id="1",
+            cliente="A",
+            servicio="VIP",
+            ttr_h=5.0,
+            sla_objetivo_h=12.0,
+            cumplido=True,
+        )
+    ]
+    data = ResultadoSLA(
+        kpi=kpi,
+        detalle=detalle,
+        breakdown_por_servicio={"VIP": kpi},
+        sin_cierre=0,
+    )
+    path = export_docx(data, params, tmp_path)
+    assert Path(path).exists()
+    doc = Document(path)
+    assert "Julio 2024" in doc.paragraphs[0].text


### PR DESCRIPTION
## Resumen
- Implementa módulo `informes_sla` con procesamiento, KPIs y generación de reportes DOCX/PDF.
- Añade flujo conversacional `/sla` en el bot de Telegram con manejo de archivos y período.
- Actualiza handlers, documentación y pruebas para integrar el nuevo informe.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7595eae5083308e4f92791402093b