### PR TITLE
[bot_telegram] Ajuste de filtros de comandos para aiogram 3

### DIFF
--- a/bot_telegram/handlers/basic.py
+++ b/bot_telegram/handlers/basic.py
@@ -3,6 +3,7 @@
 # Descripción: Comandos básicos (/start, /help, /ping) y handler de fallback
 
 from aiogram import Router
+from aiogram.filters import Command, CommandStart
 from aiogram.types import Message
 
 from bot_telegram.ui.reply_keyboard import get_main_reply_keyboard
@@ -10,7 +11,7 @@ from bot_telegram.ui.reply_keyboard import get_main_reply_keyboard
 router = Router()
 
 
-@router.message(commands={"start"})
+@router.message(CommandStart())
 async def cmd_start(msg: Message):
     """Mensaje de bienvenida opcional mostrando el teclado de atajos."""
     await msg.answer(
@@ -19,12 +20,12 @@ async def cmd_start(msg: Message):
     )
 
 
-@router.message(commands={"help"})
+@router.message(Command("help"))
 async def cmd_help(msg: Message):
     await msg.answer("Comandos disponibles:\n/start – bienvenida\n/ping – prueba de latencia\n/help – esta ayuda")
 
 
-@router.message(commands={"ping"})
+@router.message(Command("ping"))
 async def cmd_ping(msg: Message):
     await msg.answer("pong 🏓")
 

--- a/bot_telegram/handlers/menu.py
+++ b/bot_telegram/handlers/menu.py
@@ -5,6 +5,7 @@
 import logging
 
 from aiogram import F, Router
+from aiogram.filters import Command
 from aiogram.fsm.context import FSMContext
 from aiogram.types import CallbackQuery, Message
 
@@ -17,7 +18,7 @@ router = Router()
 logger = logging.getLogger(__name__)
 
 
-@router.message(commands={"menu"})
+@router.message(Command("menu"))
 async def cmd_menu(msg: Message) -> None:
     """Muestra el menú principal cuando se usa /menu."""
     logger.info(


### PR DESCRIPTION
## Resumen
- Corrige decoradores de comandos usando `Command` y `CommandStart` de aiogram 3
- Alinea handler del menú al nuevo estilo de filtros

## Pruebas
- `python -m py_compile bot_telegram/handlers/basic.py bot_telegram/handlers/menu.py`
- `python -m bot_telegram.app` *(falla: Falta TELEGRAM_BOT_TOKEN en el entorno)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a75b8b6d10833080c5541236c0e944