### PR TITLE
Fijar versiones de dependencias críticas

### DIFF
--- a/docs/decisiones.md
+++ b/docs/decisiones.md
@@ -2,6 +2,13 @@
 # Ubicación de archivo: docs/decisiones.md
 # Descripción: Registro de decisiones técnicas del proyecto
 
+## 2025-08-21 — Fijación de versiones de dependencias
+
+- **Contexto:** Las dependencias `sqlalchemy`, `psycopg[binary]` y `orjson` no tenían versiones fijas, lo que provocaba diferencias entre entornos.
+- **Decisión:** Establecer versiones explícitas en `requirements.txt` para asegurar un entorno replicable.
+- **Alternativas:** Mantener versiones flotantes y resolver conflictos cuando aparezcan.
+- **Impacto:** Facilita la reproducción de entornos y reduce fallos por cambios inesperados en las dependencias.
+
 ## 2025-08-21 — Unificación de flujos del bot
 
 - **Contexto:** Los comandos y botones del bot ejecutaban lógica separada, lo que dificultaba diagnosticar problemas con `callback_query` y generaba duplicidad de código.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@
 # Ubicación de archivo: requirements.txt
 # Descripción: Dependencias del proyecto
 
-fastapi==0.110.1
-uvicorn[standard]==0.29.0
-pytest==8.3.2
-httpx==0.27.0
-sqlalchemy
-psycopg[binary]
-orjson
+fastapi==0.110.1  # Framework web para APIs
+uvicorn[standard]==0.29.0  # Servidor ASGI para FastAPI
+pytest==8.3.2  # Marco de pruebas
+httpx==0.27.0  # Cliente HTTP asíncrono
+sqlalchemy==2.0.32  # ORM para interactuar con la base de datos
+psycopg[binary]==3.1.19  # Driver PostgreSQL en formato binario
+orjson==3.10.3  # Serializador JSON de alto rendimiento


### PR DESCRIPTION
## Resumen
- Fijar versiones para `sqlalchemy`, `psycopg[binary]` y `orjson` en `requirements.txt` y documentar el propósito de cada dependencia.
- Registrar en `docs/decisiones.md` la decisión de congelar versiones para entornos reproducibles.

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fallan 6 tests durante la fase de recolección)*

------
https://chatgpt.com/codex/tasks/task_e_68a75d8eb7b4833083da47b74d41af85