### PR TITLE
[core] Limpieza de imports y documentación

### DIFF
--- a/core/repositories/conversations.py
+++ b/core/repositories/conversations.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Optional
 
 import psycopg
 
@@ -16,12 +15,14 @@ def insert_conversation(conn: psycopg.Connection, tg_user_id: int) -> int:
     """Inserta una nueva conversación y devuelve su ID."""
     with conn.cursor() as cur:
         cur.execute(
-            "INSERT INTO app.conversations (tg_user_id) VALUES (%s) RETURNING id",
+            "INSERT INTO app.conversations (tg_user_id) "
+            "VALUES (%s) RETURNING id",
             (tg_user_id,),
         )
         new_id = cur.fetchone()[0]
         conn.commit()
-    logger.info("conversación creada", extra={"tg_user_id": tg_user_id, "conversation_id": new_id})
+    logger.info(
+        "conversación creada",
+        extra={"tg_user_id": tg_user_id, "conversation_id": new_id},
+    )
     return new_id
-
-

--- a/core/repositories/messages.py
+++ b/core/repositories/messages.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Optional
 
 import psycopg
 
@@ -53,5 +52,3 @@ def insert_message(
             "confidence": confidence,
         },
     )
-
-

--- a/docs/db.md
+++ b/docs/db.md
@@ -13,3 +13,5 @@ La cadena DSN se construye a partir de variables de entorno:
 
 La función `db_health` ejecuta una consulta simple `SELECT 1` y obtiene la versión del servidor
 para verificar el estado de la base de datos.
+
+Se limpiaron imports innecesarios en los repositorios de conversaciones y mensajes para mantener el código conforme a PEP8.


### PR DESCRIPTION
## Resumen
- Eliminar imports `Optional` sin uso en repositorios de conversaciones y mensajes
- Ajustar formato de SQL y logging en repositorio de conversaciones para cumplir PEP8
- Documentar limpieza de imports en `docs/db.md`

## Pruebas
- `python -m flake8 core/repositories/conversations.py core/repositories/messages.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a75e48f4888330952fe5be3db65f3e