### PR TITLE
[api] Manejo de errores en health de base de datos

### DIFF
--- a/api/app/db.py
+++ b/api/app/db.py
@@ -2,7 +2,11 @@
 # Ubicación de archivo: api/app/db.py
 # Descripción: Conexión básica a PostgreSQL usando SQLAlchemy + Psycopg 3
 from os import getenv
+import logging
 from sqlalchemy import create_engine, text
+
+
+logger = logging.getLogger(__name__)
 
 DB_HOST = getenv("POSTGRES_HOST", "postgres")
 DB_PORT = getenv("POSTGRES_PORT", "5432")
@@ -16,8 +20,12 @@ engine = create_engine(DSN, pool_pre_ping=True, pool_recycle=1800)
 
 def db_health() -> dict:
     """Realiza un SELECT 1 y devuelve info básica."""
-    with engine.connect() as conn:
-        conn.execute(text("SELECT 1"))
-        server_version = conn.exec_driver_sql("SHOW server_version").scalar()
+    try:
+        with engine.connect() as conn:
+            conn.execute(text("SELECT 1"))
+            server_version = conn.exec_driver_sql("SHOW server_version").scalar()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("db_health_fallo", extra={"error": str(exc)})
+        return {"db": "error", "detail": str(exc)}
     return {"db": "ok", "server_version": server_version}
 

--- a/api/app/routes/health.py
+++ b/api/app/routes/health.py
@@ -10,11 +10,12 @@ router = APIRouter()
 
 @router.get("/health")
 def health():
-    return {
+    base_response = {
         "status": "ok",
         "service": "api",
-        "time": datetime.now(timezone.utc).isoformat()
+        "time": datetime.now(timezone.utc).isoformat(),
     }
+    return {**base_response, **db_health()}
 
 @router.get("/db-check")
 def db_check():

--- a/docs/api.md
+++ b/docs/api.md
@@ -5,14 +5,16 @@
 ## Endpoint de salud
 
 - **Ruta:** `GET /health`
-- **Descripción:** Verifica el estado del servicio.
+- **Descripción:** Verifica el estado del servicio y la conexión a la base de datos.
 - **Respuesta:**
 
   ```json
   {
     "status": "ok",
     "service": "api",
-    "time": "2024-01-01T00:00:00+00:00"
+    "time": "2024-01-01T00:00:00+00:00",
+    "db": "ok",
+    "server_version": "16.0"
   }
   ```
 
@@ -20,7 +22,7 @@
 
 - **Ruta:** `GET /db-check`
 - **Descripción:** Ejecuta un `SELECT 1` y devuelve la versión del servidor PostgreSQL.
-- **Respuesta:**
+- **Respuesta exitosa:**
 
   ```json
   {
@@ -28,4 +30,15 @@
     "server_version": "16.0"
   }
   ```
+
+- **Respuesta con error:**
+
+  ```json
+  {
+    "db": "error",
+    "detail": "detalle del error"
+  }
+  ```
+
+  El campo `detail` incluye el mensaje original de la excepción capturada.
 


### PR DESCRIPTION
## Resumen
- Se añadió manejo de excepciones y logging en `db_health`
- El endpoint `/health` ahora incluye el estado de la base de datos
- Documentación actualizada para reflejar posibles errores de conexión

## Pruebas
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7617aff9083309634086eeafc6cad