### PR TITLE
[informes] Centraliza conversión a PDF y parametriza rutas

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,13 @@ OLLAMA_URL=http://ollama:11434
 INTENT_THRESHOLD=0.7
 LANG=es
 LOG_RAW_TEXT=false
+SLA_TEMPLATE_PATH=/app/templates/sla.docx
+REP_TEMPLATE_PATH=/app/templates/repetitividad.docx
+REPORTS_DIR=/app/data/reports
+UPLOADS_DIR=/app/data/uploads
+SOFFICE_BIN=/usr/bin/soffice
+MAPS_ENABLED=false
+MAPS_LIGHTWEIGHT=true
 ```
 
 ---

--- a/bot_telegram/flows/repetitividad.py
+++ b/bot_telegram/flows/repetitividad.py
@@ -3,7 +3,6 @@
 # Descripción: Flujo para recibir Excel y generar el informe de repetitividad
 
 import logging
-import os
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -13,7 +12,7 @@ from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
 from aiogram.types import FSInputFile, Message
 
-from modules.informes_repetitividad.config import BASE_UPLOADS
+from modules.informes_repetitividad.config import BASE_UPLOADS, SOFFICE_BIN
 from modules.informes_repetitividad.runner import run
 
 router = Router()
@@ -81,7 +80,7 @@ async def on_period(msg: Message, state: FSMContext) -> None:
 
     data = await state.get_data()
     file_path = data.get("file_path")
-    soffice_bin = os.getenv("SOFFICE_BIN")
+    soffice_bin = SOFFICE_BIN
     paths = run(file_path, mes, anio, soffice_bin)
 
     await msg.answer_document(FSInputFile(paths["docx"]))

--- a/bot_telegram/flows/sla.py
+++ b/bot_telegram/flows/sla.py
@@ -3,7 +3,6 @@
 # Descripción: Flujo para recibir Excel y generar el informe de SLA
 
 import logging
-import os
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -13,7 +12,7 @@ from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
 from aiogram.types import FSInputFile, Message
 
-from modules.informes_sla.config import BASE_UPLOADS
+from modules.informes_sla.config import BASE_UPLOADS, SOFFICE_BIN
 from modules.informes_sla.runner import run
 
 router = Router()
@@ -82,7 +81,7 @@ async def on_period(msg: Message, state: FSMContext) -> None:
 
     data = await state.get_data()
     file_path = data.get("file_path")
-    soffice_bin = os.getenv("SOFFICE_BIN")
+    soffice_bin = SOFFICE_BIN
     resultado = run(file_path, mes, anio, soffice_bin)
 
     await msg.answer_document(FSInputFile(resultado["docx"]))
@@ -90,7 +89,7 @@ async def on_period(msg: Message, state: FSMContext) -> None:
         await msg.answer_document(FSInputFile(resultado["pdf"]))
     if resultado["resultado"].sin_cierre:
         await msg.answer(
-            f"Se excluyeron {resultado['resultado'].sin_cierre} casos sin fecha de cierre"
+            f"Se excluyeron {resultado['resultado'].sin_cierre} casos sin fecha de cierre",
         )
 
     logger.info(

--- a/deploy/env.sample
+++ b/deploy/env.sample
@@ -21,5 +21,11 @@ INTENT_THRESHOLD=0.7
 LANG=es
 LOG_RAW_TEXT=false
 
-# LibreOffice
+# Informes
+SLA_TEMPLATE_PATH=/app/templates/sla.docx
+REP_TEMPLATE_PATH=/app/templates/repetitividad.docx
+REPORTS_DIR=/app/data/reports
+UPLOADS_DIR=/app/data/uploads
 SOFFICE_BIN=/usr/bin/soffice
+MAPS_ENABLED=false
+MAPS_LIGHTWEIGHT=true

--- a/docs/informes/repetitividad.md
+++ b/docs/informes/repetitividad.md
@@ -24,4 +24,9 @@
 - Archivos generados en `/app/data/reports/` dentro del contenedor del bot.
 
 ## Variables de entorno
+- `REP_TEMPLATE_PATH=/app/templates/repetitividad.docx` ruta de la plantilla.
+- `REPORTS_DIR=/app/data/reports` destino de los informes.
+- `UPLOADS_DIR=/app/data/uploads` ubicación temporal de archivos subidos.
 - `SOFFICE_BIN=/usr/bin/soffice` para habilitar la conversión a PDF (opcional).
+- `MAPS_ENABLED=false` habilita mapas cuando es `true`.
+- `MAPS_LIGHTWEIGHT=true` usa Matplotlib sin stack geoespacial.

--- a/docs/informes/sla.md
+++ b/docs/informes/sla.md
@@ -37,4 +37,7 @@ Mapeos admitidos: `TicketID`→`ID`, `Apertura`→`FECHA_APERTURA`, `Cierre`→`
 - Archivos en `/app/data/reports/` dentro del contenedor.
 
 ## Variables de entorno
+- `SLA_TEMPLATE_PATH=/app/templates/sla.docx` ruta de la plantilla.
+- `REPORTS_DIR=/app/data/reports` destino de los informes.
+- `UPLOADS_DIR=/app/data/uploads` ubicación temporal de archivos subidos.
 - `SOFFICE_BIN=/usr/bin/soffice` para habilitar PDF (opcional).

--- a/modules/common/__init__.py
+++ b/modules/common/__init__.py
@@ -1,0 +1,4 @@
+# Nombre de archivo: __init__.py
+# Ubicación de archivo: modules/common/__init__.py
+# Descripción: Inicializa el paquete de utilidades comunes
+

--- a/modules/common/libreoffice_export.py
+++ b/modules/common/libreoffice_export.py
@@ -1,0 +1,57 @@
+# Nombre de archivo: libreoffice_export.py
+# Ubicación de archivo: modules/common/libreoffice_export.py
+# Descripción: Conversión de archivos DOCX a PDF usando LibreOffice en modo headless
+
+import logging
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def convert_to_pdf(docx_path: str, soffice_bin: str) -> str:
+    """Convierte un DOCX a PDF utilizando LibreOffice.
+
+    Parameters
+    ----------
+    docx_path: str
+        Ruta del archivo DOCX de origen.
+    soffice_bin: str
+        Ruta al ejecutable de LibreOffice (`soffice`).
+
+    Returns
+    -------
+    str
+        Ruta absoluta del PDF generado.
+
+    Raises
+    ------
+    Exception
+        Propaga cualquier error ocurrido durante la conversión.
+    """
+    out_dir = Path(docx_path).parent
+    try:
+        subprocess.run(
+            [
+                soffice_bin,
+                "--headless",
+                "--convert-to",
+                "pdf",
+                docx_path,
+                "--outdir",
+                str(out_dir),
+            ],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except Exception as exc:  # pragma: no cover - logging
+        logger.exception("action=convert_to_pdf error=%s", exc)
+        raise
+
+    pdf_path = out_dir / (Path(docx_path).stem + ".pdf")
+    if not pdf_path.exists():  # pragma: no cover - sanity check
+        raise FileNotFoundError(f"No se generó el PDF en {pdf_path}")
+    logger.info("action=convert_to_pdf path=%s", pdf_path)
+    return str(pdf_path)
+

--- a/modules/informes_repetitividad/config.py
+++ b/modules/informes_repetitividad/config.py
@@ -2,8 +2,21 @@
 # Ubicación de archivo: modules/informes_repetitividad/config.py
 # Descripción: Configuración y constantes para el informe de repetitividad
 
+import os
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional
+
+# Paths configurables mediante variables de entorno
+REP_TEMPLATE_PATH = Path(os.getenv("REP_TEMPLATE_PATH", "/app/templates/repetitividad.docx"))
+REPORTS_DIR = Path(os.getenv("REPORTS_DIR", "/app/data/reports"))
+UPLOADS_DIR = Path(os.getenv("UPLOADS_DIR", "/app/data/uploads"))
+SOFFICE_BIN: Optional[str] = os.getenv("SOFFICE_BIN")
+MAPS_ENABLED: bool = os.getenv("MAPS_ENABLED", "false").lower() == "true"
+MAPS_LIGHTWEIGHT: bool = os.getenv("MAPS_LIGHTWEIGHT", "true").lower() == "true"
+
+# Alias para compatibilidad con otros módulos
+BASE_UPLOADS = UPLOADS_DIR
+BASE_REPORTS = REPORTS_DIR
 
 # Mapeo de columnas esperadas en el Excel de casos
 COLUMNAS_MAPPER: Dict[str, str] = {
@@ -38,7 +51,3 @@ MESES_ES: List[str] = [
     "noviembre",
     "diciembre",
 ]
-
-# Directorios base de trabajo dentro del contenedor del bot
-BASE_UPLOADS = Path("/app/data/uploads")
-BASE_REPORTS = Path("/app/data/reports")

--- a/modules/informes_repetitividad/report.py
+++ b/modules/informes_repetitividad/report.py
@@ -3,7 +3,6 @@
 # Descripción: Generación de archivos DOCX y PDF para el informe de repetitividad
 
 import logging
-import subprocess
 from pathlib import Path
 from typing import Optional
 
@@ -12,6 +11,7 @@ from docx.enum.text import WD_ALIGN_PARAGRAPH
 from docx.oxml import OxmlElement
 from docx.oxml.ns import qn
 
+from modules.common.libreoffice_export import convert_to_pdf
 from .config import MESES_ES
 from .schemas import Params, ResultadoRepetitividad
 
@@ -61,34 +61,12 @@ def export_docx(data: ResultadoRepetitividad, periodo: Params, out_dir: str) -> 
     return str(docx_path)
 
 
-def maybe_export_pdf(docx_path: str, out_dir: str, soffice_bin: Optional[str]) -> Optional[str]:
+def maybe_export_pdf(docx_path: str, soffice_bin: Optional[str]) -> Optional[str]:
     """Convierte el DOCX a PDF si LibreOffice está disponible."""
     if not soffice_bin:
         return None
-
-    out_dir_path = Path(out_dir)
-    out_dir_path.mkdir(parents=True, exist_ok=True)
     try:
-        subprocess.run(
-            [
-                soffice_bin,
-                "--headless",
-                "--convert-to",
-                "pdf",
-                docx_path,
-                "--outdir",
-                str(out_dir_path),
-            ],
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-    except Exception as exc:  # pragma: no cover - logging
-        logger.exception("action=maybe_export_pdf error=%s", exc)
+        return convert_to_pdf(docx_path, soffice_bin)
+    except Exception:  # pragma: no cover - logging
+        logger.exception("action=maybe_export_pdf error")
         return None
-
-    pdf_path = Path(out_dir) / (Path(docx_path).stem + ".pdf")
-    if pdf_path.exists():
-        logger.info("action=maybe_export_pdf path=%s", pdf_path)
-        return str(pdf_path)
-    return None

--- a/modules/informes_repetitividad/runner.py
+++ b/modules/informes_repetitividad/runner.py
@@ -21,7 +21,7 @@ def run(file_path: str, mes: int, anio: int, soffice_bin: Optional[str]) -> Dict
 
     params = Params(periodo_mes=mes, periodo_anio=anio)
     docx_path = report.export_docx(resultado, params, str(BASE_REPORTS))
-    pdf_path = report.maybe_export_pdf(docx_path, str(BASE_REPORTS), soffice_bin)
+    pdf_path = report.maybe_export_pdf(docx_path, soffice_bin)
 
     logger.info(
         "action=run mes=%s anio=%s docx=%s pdf=%s total=%s repetitivos=%s",

--- a/modules/informes_sla/config.py
+++ b/modules/informes_sla/config.py
@@ -2,8 +2,19 @@
 # Ubicación de archivo: modules/informes_sla/config.py
 # Descripción: Configuración y constantes para el informe de SLA
 
+import os
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional
+
+# Paths configurables mediante variables de entorno
+SLA_TEMPLATE_PATH = Path(os.getenv("SLA_TEMPLATE_PATH", "/app/templates/sla.docx"))
+REPORTS_DIR = Path(os.getenv("REPORTS_DIR", "/app/data/reports"))
+UPLOADS_DIR = Path(os.getenv("UPLOADS_DIR", "/app/data/uploads"))
+SOFFICE_BIN: Optional[str] = os.getenv("SOFFICE_BIN")
+
+# Alias para compatibilidad con módulos existentes
+BASE_UPLOADS = UPLOADS_DIR
+BASE_REPORTS = REPORTS_DIR
 
 # Mapeo de nombres de columnas crudas a nombres canónicos
 COLUMNAS_MAPPER: Dict[str, str] = {
@@ -53,7 +64,3 @@ MESES_ES: List[str] = [
     "noviembre",
     "diciembre",
 ]
-
-# Directorios de trabajo dentro del contenedor del bot
-BASE_UPLOADS = Path("/app/data/uploads")
-BASE_REPORTS = Path("/app/data/reports")

--- a/modules/informes_sla/runner.py
+++ b/modules/informes_sla/runner.py
@@ -22,7 +22,7 @@ def run(file_path: str, mes: int, anio: int, soffice_bin: Optional[str]) -> Dict
 
     params = Params(periodo_mes=mes, periodo_anio=anio)
     docx_path = report.export_docx(resultado, params, str(BASE_REPORTS))
-    pdf_path = report.maybe_export_pdf(docx_path, str(BASE_REPORTS), soffice_bin)
+    pdf_path = report.maybe_export_pdf(docx_path, soffice_bin)
 
     logger.info(
         "action=run mes=%s anio=%s docx=%s pdf=%s total=%s incumplidos=%s pct_cumplimiento=%.2f excluidos=%s",

--- a/tests/test_libreoffice_export.py
+++ b/tests/test_libreoffice_export.py
@@ -1,0 +1,22 @@
+# Nombre de archivo: test_libreoffice_export.py
+# Ubicación de archivo: tests/test_libreoffice_export.py
+# Descripción: Pruebas del helper de conversión a PDF con LibreOffice
+
+from pathlib import Path
+
+from modules.common.libreoffice_export import convert_to_pdf
+
+
+def test_convert_to_pdf_crea_archivo(monkeypatch, tmp_path):
+    docx = tmp_path / "archivo.docx"
+    docx.write_text("contenido")
+    pdf_esperado = tmp_path / "archivo.pdf"
+
+    def fake_run(cmd, check, stdout, stderr):
+        pdf_esperado.write_text("pdf")
+
+    monkeypatch.setattr("modules.common.libreoffice_export.subprocess.run", fake_run)
+
+    ruta_pdf = convert_to_pdf(str(docx), "soffice")
+    assert Path(ruta_pdf) == pdf_esperado
+    assert pdf_esperado.exists()


### PR DESCRIPTION
## Resumen
- Centralización de la conversión a PDF mediante `convert_to_pdf` reutilizable.
- Configuración de rutas y plantillas por variables de entorno en informes.
- Actualización de flujos del bot para usar la configuración común.

## Pruebas
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a76a22d940833085ab3ea222b16ce0