### PR TITLE
[bot_telegram] Validaciones y logs en flujo de repetitividad

### DIFF
--- a/bot_telegram/flows/repetitividad.py
+++ b/bot_telegram/flows/repetitividad.py
@@ -2,6 +2,7 @@
 # Ubicación de archivo: bot_telegram/flows/repetitividad.py
 # Descripción: Flujo para recibir Excel y generar el informe de repetitividad
 
+import json
 import logging
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -10,13 +11,32 @@ from aiogram import F, Router
 from aiogram.filters import Command
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
-from aiogram.types import FSInputFile, Message
+from aiogram.types import Document, FSInputFile, Message
 
 from modules.informes_repetitividad.config import BASE_UPLOADS, SOFFICE_BIN
 from modules.informes_repetitividad.runner import run
 
 router = Router()
 logger = logging.getLogger(__name__)
+
+
+def build_repetitividad_prompt() -> str:
+    """Devuelve el texto inicial que solicita el archivo al usuario."""
+    return (
+        "📊 Enviá el Excel 'Casos' en formato .xlsx (máx 10MB) o /cancel para salir"
+    )
+
+
+def validate_document(document: Document) -> tuple[bool, str]:
+    """Valida extensión y tamaño del archivo recibido."""
+    if not document.file_name.lower().endswith(".xlsx"):
+        return False, "El archivo debe tener extensión .xlsx. Intentá nuevamente"
+    if document.file_size and document.file_size > 10 * 1024 * 1024:
+        return (
+            False,
+            "El archivo excede el tamaño máximo de 10MB. Intentá nuevamente",
+        )
+    return True, ""
 
 
 class RepetitividadStates(StatesGroup):
@@ -28,14 +48,18 @@ async def start_repetitividad_flow(msg: Message, state: FSMContext, origin: str)
     """Inicia el flujo solicitando el archivo Excel."""
     tg_user_id = msg.from_user.id
     logger.info(
-        "service=bot route=%s action=start_repetitividad_flow tg_user_id=%s",
-        origin,
-        tg_user_id,
+        json.dumps(
+            {
+                "service": "bot",
+                "flow": "repetitividad",
+                "tg_user_id": tg_user_id,
+                "event": "start",
+                "origin": origin,
+            }
+        )
     )
     await state.clear()
-    await msg.answer(
-        "📊 Enviá el Excel 'Casos' en formato .xlsx o /cancel para salir"
-    )
+    await msg.answer(build_repetitividad_prompt())
     await state.set_state(RepetitividadStates.WAITING_FILE)
 
 
@@ -43,8 +67,20 @@ async def start_repetitividad_flow(msg: Message, state: FSMContext, origin: str)
 async def on_file(msg: Message, state: FSMContext) -> None:
     """Recibe y almacena el archivo enviado por el usuario."""
     document = msg.document
-    if not document.file_name.lower().endswith(".xlsx"):
-        await msg.answer("El archivo debe tener extensión .xlsx. Intentá nuevamente")
+    is_valid, error = validate_document(document)
+    if not is_valid:
+        logger.warning(
+            json.dumps(
+                {
+                    "service": "bot",
+                    "flow": "repetitividad",
+                    "tg_user_id": msg.from_user.id,
+                    "event": "invalid_file",
+                    "reason": error,
+                }
+            )
+        )
+        await msg.answer(error)
         return
 
     user_dir = BASE_UPLOADS / "telegram" / str(msg.from_user.id)
@@ -52,6 +88,18 @@ async def on_file(msg: Message, state: FSMContext) -> None:
     file_path = user_dir / document.file_name
     await document.download(destination=file_path)
     await state.update_data(file_path=str(file_path))
+
+    logger.info(
+        json.dumps(
+            {
+                "service": "bot",
+                "flow": "repetitividad",
+                "tg_user_id": msg.from_user.id,
+                "event": "file_received",
+                "file": document.file_name,
+            }
+        )
+    )
 
     prev_month = datetime.now().replace(day=1) - timedelta(days=1)
     sugerencia = prev_month.strftime("%m/%Y")
@@ -63,7 +111,9 @@ async def on_file(msg: Message, state: FSMContext) -> None:
 
 @router.message(RepetitividadStates.WAITING_FILE)
 async def on_invalid_file(msg: Message) -> None:
-    await msg.answer("Necesito un archivo .xlsx válido o /cancel para salir")
+    await msg.answer(
+        "Necesito un archivo .xlsx válido (máx 10MB) o /cancel para salir"
+    )
 
 
 @router.message(RepetitividadStates.WAITING_PERIOD, F.text)
@@ -86,13 +136,17 @@ async def on_period(msg: Message, state: FSMContext) -> None:
     await msg.answer_document(FSInputFile(paths["docx"]))
     if paths.get("pdf"):
         await msg.answer_document(FSInputFile(paths["pdf"]))
-
     logger.info(
-        "service=bot flow=repetitividad tg_user_id=%s file=%s periodo=%02d/%04d",
-        msg.from_user.id,
-        Path(file_path).name,
-        mes,
-        anio,
+        json.dumps(
+            {
+                "service": "bot",
+                "flow": "repetitividad",
+                "tg_user_id": msg.from_user.id,
+                "event": "report_generated",
+                "file": Path(file_path).name,
+                "periodo": f"{mes:02d}/{anio:04d}",
+            }
+        )
     )
     await state.clear()
 
@@ -108,4 +162,16 @@ async def on_cancel(msg: Message, state: FSMContext) -> None:
     if await state.get_state() is not None:
         await state.clear()
         await msg.answer("Operación cancelada")
+        logger.info(
+            json.dumps(
+                {
+                    "service": "bot",
+                    "flow": "repetitividad",
+                    "tg_user_id": msg.from_user.id,
+                    "event": "cancel",
+                }
+            )
+        )
+    else:
+        await msg.answer("No hay una operación activa")
 

--- a/docs/informes/repetitividad.md
+++ b/docs/informes/repetitividad.md
@@ -4,6 +4,7 @@
 
 ## Insumos requeridos
 - Excel "Casos" en formato `.xlsx`.
+- Tamaño máximo permitido: 10MB.
 - Columnas mínimas: `CLIENTE`, `SERVICIO`, `FECHA` y opcional `ID_SERVICIO`.
 - Los datos del cliente **BANCO MACRO SA** nunca se filtran automáticamente.
 

--- a/tests/test_flows_builders.py
+++ b/tests/test_flows_builders.py
@@ -2,6 +2,7 @@
 # Ubicación de archivo: tests/test_flows_builders.py
 # Descripción: Pruebas de los builders de respuesta de los flujos del bot
 
+from bot_telegram.flows.repetitividad import build_repetitividad_prompt
 from bot_telegram.flows.sla import build_sla_response
 
 
@@ -10,3 +11,10 @@ def test_build_sla_response() -> None:
     text = build_sla_response()
     assert "📈" in text
     assert "Excel" in text
+
+
+def test_build_repetitividad_prompt() -> None:
+    """Verifica que el builder de repetitividad solicita correctamente el archivo."""
+    text = build_repetitividad_prompt()
+    assert ".xlsx" in text
+    assert "/cancel" in text

--- a/tests/test_repetitividad_flow_validations.py
+++ b/tests/test_repetitividad_flow_validations.py
@@ -1,0 +1,31 @@
+# Nombre de archivo: test_repetitividad_flow_validations.py
+# Ubicación de archivo: tests/test_repetitividad_flow_validations.py
+# Descripción: Pruebas de validaciones del flujo de repetitividad
+
+from types import SimpleNamespace
+
+from bot_telegram.flows.repetitividad import validate_document
+
+
+def test_validate_document_extension() -> None:
+    """Rechaza archivos con extensión diferente a .xlsx."""
+    doc = SimpleNamespace(file_name="datos.txt", file_size=100)
+    valido, error = validate_document(doc)
+    assert not valido
+    assert "extensión .xlsx" in error
+
+
+def test_validate_document_size() -> None:
+    """Rechaza archivos mayores a 10MB."""
+    doc = SimpleNamespace(file_name="datos.xlsx", file_size=11 * 1024 * 1024)
+    valido, error = validate_document(doc)
+    assert not valido
+    assert "10MB" in error
+
+
+def test_validate_document_ok() -> None:
+    """Acepta archivos válidos."""
+    doc = SimpleNamespace(file_name="datos.xlsx", file_size=1024)
+    valido, error = validate_document(doc)
+    assert valido
+    assert error == ""


### PR DESCRIPTION
## Resumen
- Se incorporaron validaciones de extensión .xlsx y tamaño máximo de 10MB en el flujo de repetitividad.
- Se añadieron logs estructurados en formato JSON con los campos `service`, `flow` y `tg_user_id`.
- Se documentó el nuevo límite de tamaño y se ampliaron las pruebas unitarias del flujo.

## Pruebas
- `PYTHONPATH=. pytest tests/test_flows_builders.py tests/test_repetitividad_flow_validations.py`


------
https://chatgpt.com/codex/tasks/task_e_68a780079b7083308ea0132a74bbbe73