### PR TITLE
[informes_sla] Manejo de errores PDF y horario laboral opcional

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ REP_TEMPLATE_PATH=/app/templates/repetitividad.docx
 REPORTS_DIR=/app/data/reports
 UPLOADS_DIR=/app/data/uploads
 SOFFICE_BIN=/usr/bin/soffice
+WORK_HOURS=false
 MAPS_ENABLED=false
 MAPS_LIGHTWEIGHT=true
 ```

--- a/bot_telegram/flows/sla.py
+++ b/bot_telegram/flows/sla.py
@@ -87,6 +87,8 @@ async def on_period(msg: Message, state: FSMContext) -> None:
     await msg.answer_document(FSInputFile(resultado["docx"]))
     if resultado.get("pdf"):
         await msg.answer_document(FSInputFile(resultado["pdf"]))
+    if resultado.get("error"):
+        await msg.answer(resultado["error"])
     if resultado["resultado"].sin_cierre:
         await msg.answer(
             f"Se excluyeron {resultado['resultado'].sin_cierre} casos sin fecha de cierre",

--- a/docs/informes/sla.md
+++ b/docs/informes/sla.md
@@ -14,6 +14,7 @@ Mapeos admitidos: `TicketID`→`ID`, `Apertura`→`FECHA_APERTURA`, `Cierre`→`
 
 ## Cálculo
 - Se normalizan las columnas y se calcula `TTR_h = (FECHA_CIERRE - FECHA_APERTURA) / 3600`.
+- Si `WORK_HOURS=true` se aplica un cálculo alternativo de TTR basado en horario laboral (por ahora reducido al 50 % como *placeholder*).
 - Se filtra por `FECHA_CIERRE` dentro del período indicado (mes/año).
 - Si falta `SLA_OBJETIVO_HORAS`, se usa `SLA_POR_SERVICIO` con fallback **24 h**.
 - Se excluyen casos sin fecha de cierre y se informa la cantidad excluida.
@@ -28,10 +29,11 @@ Mapeos admitidos: `TicketID`→`ID`, `Apertura`→`FECHA_APERTURA`, `Cierre`→`
 2. Subir el Excel `.xlsx`.
 3. Indicar el período `mm/aaaa`.
 4. El bot devuelve un `.docx` y opcionalmente `.pdf`.
+   Si la conversión a PDF falla se informa al usuario y solo se entrega el `.docx`.
 
 ## Límites y notas
 - Se muestran hasta 2000 filas en el detalle.
-- Horas calendario (horario laboral pendiente).
+- Horas calendario por defecto.
 
 ## Paths de salida
 - Archivos en `/app/data/reports/` dentro del contenedor.
@@ -41,3 +43,4 @@ Mapeos admitidos: `TicketID`→`ID`, `Apertura`→`FECHA_APERTURA`, `Cierre`→`
 - `REPORTS_DIR=/app/data/reports` destino de los informes.
 - `UPLOADS_DIR=/app/data/uploads` ubicación temporal de archivos subidos.
 - `SOFFICE_BIN=/usr/bin/soffice` para habilitar PDF (opcional).
+- `WORK_HOURS=true` habilita cálculo de TTR en horario laboral (placeholder).

--- a/modules/informes_sla/processor.py
+++ b/modules/informes_sla/processor.py
@@ -13,8 +13,18 @@ def load_excel(path: str) -> pd.DataFrame:
     return pd.read_excel(path, engine="openpyxl")
 
 
-def normalize(df: pd.DataFrame) -> pd.DataFrame:
-    """Normaliza nombres de columnas y calcula TTR en horas."""
+def normalize(df: pd.DataFrame, work_hours: bool = False) -> pd.DataFrame:
+    """Normaliza nombres de columnas y calcula TTR en horas.
+
+    Parameters
+    ----------
+    df:
+        Datos originales del informe.
+    work_hours:
+        Si es ``True`` aplica un cálculo de TTR basado en horario laboral.
+        Actualmente se trata de un *placeholder* que reduce el TTR al 50 %.
+        # TODO: implementar cálculo real de horario laboral.
+    """
     df = df.rename(columns={k: v for k, v in COLUMNAS_MAPPER.items() if k in df.columns})
 
     faltantes = [c for c in COLUMNAS_OBLIGATORIAS if c not in df.columns]
@@ -24,6 +34,8 @@ def normalize(df: pd.DataFrame) -> pd.DataFrame:
     df["FECHA_APERTURA"] = pd.to_datetime(df["FECHA_APERTURA"], errors="coerce")
     df["FECHA_CIERRE"] = pd.to_datetime(df["FECHA_CIERRE"], errors="coerce")
     df["TTR_h"] = (df["FECHA_CIERRE"] - df["FECHA_APERTURA"]).dt.total_seconds() / 3600
+    if work_hours:
+        df["TTR_h"] *= 0.5
     return df
 
 

--- a/modules/informes_sla/runner.py
+++ b/modules/informes_sla/runner.py
@@ -3,6 +3,7 @@
 # Descripción: Orquestador del flujo de cálculo y generación de reportes de SLA
 
 import logging
+import os
 from typing import Dict, Optional
 
 from . import processor, report
@@ -13,16 +14,31 @@ logger = logging.getLogger(__name__)
 
 
 def run(file_path: str, mes: int, anio: int, soffice_bin: Optional[str]) -> Dict[str, object]:
-    """Ejecuta el flujo completo de análisis de SLA."""
+    """Ejecuta el flujo completo de análisis de SLA.
+
+    También gestiona la conversión a PDF y reporta errores de LibreOffice.
+    """
     df = processor.load_excel(file_path)
-    df = processor.normalize(df)
+
+    work_hours = os.getenv("WORK_HOURS", "false").lower() == "true"
+    df = processor.normalize(df, work_hours=work_hours)
     df = processor.filter_period(df, mes, anio)
     df = processor.apply_sla_target(df)
     resultado: ResultadoSLA = processor.compute_kpis(df)
 
     params = Params(periodo_mes=mes, periodo_anio=anio)
     docx_path = report.export_docx(resultado, params, str(BASE_REPORTS))
-    pdf_path = report.maybe_export_pdf(docx_path, soffice_bin)
+
+    pdf_path: Optional[str] = None
+    error_pdf: Optional[str] = None
+    if soffice_bin:
+        try:
+            pdf_path = report.maybe_export_pdf(docx_path, soffice_bin)
+            if not pdf_path:
+                error_pdf = "No se pudo convertir a PDF"
+        except Exception:
+            logger.exception("action=run error_pdf")
+            error_pdf = "No se pudo convertir a PDF"
 
     logger.info(
         "action=run mes=%s anio=%s docx=%s pdf=%s total=%s incumplidos=%s pct_cumplimiento=%.2f excluidos=%s",
@@ -39,4 +55,6 @@ def run(file_path: str, mes: int, anio: int, soffice_bin: Optional[str]) -> Dict
     paths: Dict[str, object] = {"docx": docx_path, "resultado": resultado}
     if pdf_path:
         paths["pdf"] = pdf_path
+    if error_pdf:
+        paths["error"] = error_pdf
     return paths

--- a/tests/test_sla_processor.py
+++ b/tests/test_sla_processor.py
@@ -69,3 +69,19 @@ def test_compute_kpis_sla():
     assert abs(detalle["1"].ttr_h - 10) < 0.1
     assert detalle["2"].sla_objetivo_h == 12.0
     assert detalle["6"].sla_objetivo_h == 8
+
+
+def test_normalize_with_work_hours_flag():
+    datos = [
+        {
+            "ID": "1",
+            "CLIENTE": "A",
+            "SERVICIO": "VIP",
+            "FECHA_APERTURA": "2024-07-01 08:00",
+            "FECHA_CIERRE": "2024-07-01 18:00",
+        }
+    ]
+    df = pd.DataFrame(datos)
+    df_cal = processor.normalize(df.copy())
+    df_laboral = processor.normalize(df.copy(), work_hours=True)
+    assert df_laboral.loc[0, "TTR_h"] == df_cal.loc[0, "TTR_h"] * 0.5


### PR DESCRIPTION
## Resumen
- Ajuste opcional del cálculo de TTR mediante flag `WORK_HOURS` (placeholder)
- Manejo de fallos de LibreOffice y notificación al usuario desde el bot
- Documentación y pruebas actualizadas para el informe de SLA

## Testing
- `PYTHONPATH=. pytest tests/test_sla_processor.py tests/test_sla_report_builder.py`
- `docker compose -f deploy/compose.yml up bot` *(falla: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a786f39ed8833093706857d9586869