### PR TITLE
[deploy] Copia módulos esenciales para el bot

### DIFF
--- a/deploy/docker/bot.Dockerfile
+++ b/deploy/docker/bot.Dockerfile
@@ -15,6 +15,8 @@ RUN pip install --no-cache-dir -r /app/bot_requirements.txt
 
 # Copiamos solo lo necesario del proyecto
 COPY bot_telegram /app/bot_telegram
+COPY modules /app/modules
+COPY core /app/core
 
 # Usuario no root opcional (hardening)
 # RUN useradd -m bot && chown -R bot:bot /app && USER bot

--- a/docs/bot.md
+++ b/docs/bot.md
@@ -7,6 +7,9 @@
 - TELEGRAM_ALLOWED_IDS=11111111,22222222
 
 ## Arranque con Docker
+
+La imagen del bot copia los directorios `bot_telegram`, `modules` y `core` para
+que los flujos `/sla` y `/repetitividad` funcionen correctamente.
 ```bash
 docker compose -f deploy/compose.yml up -d --build bot
 docker compose -f deploy/compose.yml logs -f bot


### PR DESCRIPTION
## Resumen
- Copia `modules` y `core` en la imagen del bot de Telegram.
- Documenta que la imagen incluye los directorios necesarios para los flujos `/sla` y `/repetitividad`.

## Pruebas
- `pytest -q`
- `docker build -f deploy/docker/bot.Dockerfile -t bot-test ..` *(falla: Cannot connect to the Docker daemon)*
- `python - <<'PY' ... PY`

------
https://chatgpt.com/codex/tasks/task_e_68a78c05815083308482e35f43c474fb