### PR TITLE
[nlp_intent] Contador de fallos y TTL de caché

### DIFF
--- a/deploy/env.sample
+++ b/deploy/env.sample
@@ -20,6 +20,7 @@ OLLAMA_URL=http://ollama:11434
 INTENT_THRESHOLD=0.7
 LANG=es
 LOG_RAW_TEXT=false
+CACHE_TTL=300
 
 # Informes
 SLA_TEMPLATE_PATH=/app/templates/sla.docx

--- a/docs/nlp/intent.md
+++ b/docs/nlp/intent.md
@@ -36,7 +36,7 @@ El servicio intenta cada proveedor en ese orden mientras la confianza sea menor 
 
 ## Caché
 
-Las respuestas de clasificación se almacenan en memoria durante `CACHE_TTL` segundos (300 por defecto). Si un texto se repite dentro de ese período, la respuesta se devuelve desde caché evitando recalcularla.
+Las respuestas de clasificación se almacenan en memoria durante `CACHE_TTL` segundos (300 por defecto). Esta duración se configura con la variable de entorno `CACHE_TTL`. Si un texto se repite dentro de ese período, la respuesta se devuelve desde caché evitando recalcularla.
 
 ## Métricas
 
@@ -50,6 +50,10 @@ El endpoint `GET /metrics` devuelve estadísticas básicas:
 ```
 
 `total_requests` cuenta las llamadas a `/v1/intent:classify` y `average_latency_ms` es la latencia promedio.
+
+## Resiliencia ante fallos
+
+Cada proveedor externo mantiene un contador de errores. Tras **3** fallos consecutivos, ese proveedor se desactiva y el servicio se degrada a la heurística local para evitar más errores.
 
 ## Baja confianza
 

--- a/nlp_intent/app/service.py
+++ b/nlp_intent/app/service.py
@@ -13,6 +13,10 @@ from .schemas import IntentResponse
 from .providers import heuristic, ollama_provider, openai_provider
 from .cache import TTLCache
 
+MAX_PROVIDER_ERRORS = 3
+failure_counts: dict[str, int] = {"ollama": 0, "openai": 0}
+disabled_providers: set[str] = set()
+
 logger = logging.getLogger(__name__)
 cache = TTLCache(ttl=settings.cache_ttl)
 
@@ -44,7 +48,12 @@ async def classify_text(text: str) -> IntentResponse:
         intent, confidence = heuristic.classify(normalized)
         logger.info(
             "clasificación",
-            extra={**log_extra, "provider": "heuristic", "intent": intent, "confidence": confidence},
+            extra={
+                **log_extra,
+                "provider": "heuristic",
+                "intent": intent,
+                "confidence": confidence,
+            },
         )
         if settings.llm_provider != "auto" or confidence >= settings.intent_threshold:
             resp = IntentResponse(
@@ -56,34 +65,67 @@ async def classify_text(text: str) -> IntentResponse:
             cache.set(cache_key, resp)
             return resp
 
-    if settings.llm_provider in ("ollama", "auto"):
+    if (
+        settings.llm_provider in ("ollama", "auto")
+        and "ollama" not in disabled_providers
+    ):
         try:
             resp = await ollama_provider.classify(text, normalized)
+            failure_counts["ollama"] = 0
             logger.info(
                 "clasificación",
-                extra={**log_extra, "provider": resp.provider, "intent": resp.intent, "confidence": resp.confidence},
+                extra={
+                    **log_extra,
+                    "provider": resp.provider,
+                    "intent": resp.intent,
+                    "confidence": resp.confidence,
+                },
             )
-            if settings.llm_provider != "auto" or resp.confidence >= settings.intent_threshold:
+            if (
+                settings.llm_provider != "auto"
+                or resp.confidence >= settings.intent_threshold
+            ):
                 cache.set(cache_key, resp)
                 return resp
         except Exception as exc:  # pragma: no cover - manejo de fallos externo
+            failure_counts["ollama"] += 1
             logger.warning("ollama_fallo", extra={**log_extra, "error": str(exc)})
+            if failure_counts["ollama"] >= MAX_PROVIDER_ERRORS:
+                disabled_providers.add("ollama")
+                logger.error("ollama_desactivado", extra=log_extra)
+                if settings.llm_provider == "ollama":
+                    settings.llm_provider = "heuristic"
 
-    if settings.llm_provider in ("openai", "auto"):
+    if (
+        settings.llm_provider in ("openai", "auto")
+        and "openai" not in disabled_providers
+    ):
         try:
             resp = await openai_provider.classify(text, normalized)
+            failure_counts["openai"] = 0
             logger.info(
                 "clasificación",
-                extra={**log_extra, "provider": resp.provider, "intent": resp.intent, "confidence": resp.confidence},
+                extra={
+                    **log_extra,
+                    "provider": resp.provider,
+                    "intent": resp.intent,
+                    "confidence": resp.confidence,
+                },
             )
             cache.set(cache_key, resp)
             return resp
         except Exception as exc:  # pragma: no cover
+            failure_counts["openai"] += 1
             logger.warning("openai_fallo", extra={**log_extra, "error": str(exc)})
+            if failure_counts["openai"] >= MAX_PROVIDER_ERRORS:
+                disabled_providers.add("openai")
+                logger.error("openai_desactivado", extra=log_extra)
+                if settings.llm_provider == "openai":
+                    settings.llm_provider = "heuristic"
 
     # Fallback final
-    resp = IntentResponse(intent="Otros", confidence=0.0, provider="none", normalized_text=normalized)
+    resp = IntentResponse(
+        intent="Otros", confidence=0.0, provider="none", normalized_text=normalized
+    )
     cache.set(cache_key, resp)
     return resp
-
-

--- a/nlp_intent/tests/test_failover.py
+++ b/nlp_intent/tests/test_failover.py
@@ -1,0 +1,40 @@
+# Nombre de archivo: test_failover.py
+# Ubicación de archivo: nlp_intent/tests/test_failover.py
+# Descripción: Verifica la degradación a heurística tras fallos consecutivos del proveedor
+
+from __future__ import annotations
+
+import asyncio
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+from nlp_intent.app import service
+
+
+def _classify(text: str):
+    async def _run():
+        return await service.classify_text(text)
+
+    return asyncio.run(_run())
+
+
+def test_openai_degrade(monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    service.settings.llm_provider = "openai"
+    service.cache.clear()
+    service.failure_counts["openai"] = 0
+    service.disabled_providers.clear()
+
+    async def fake_classify(text: str, normalized: str):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(service.openai_provider, "classify", fake_classify)
+
+    for i in range(service.MAX_PROVIDER_ERRORS):
+        resp = _classify(f"hola {i}")
+        assert resp.provider == "none"
+
+    resp = _classify("hola final")
+    assert resp.provider == "heuristic"
+    assert "openai" in service.disabled_providers


### PR DESCRIPTION
## Resumen
- añade contador de fallos por proveedor para degradar a heurística tras 3 errores
- expone `CACHE_TTL` en variables de entorno y documentación
- incorpora prueba de degradación de proveedor

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a792dfca048330a09b402105b51350