### PR TITLE
[core] Logging JSON con request_id

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -10,6 +10,10 @@ from slowapi.util import get_remote_address
 from slowapi.errors import RateLimitExceeded
 
 from app.routes.health import router as health_router
+from core.logging import configure_logging
+from core.middlewares import RequestIDMiddleware
+
+configure_logging("api")
 
 
 def create_app() -> FastAPI:
@@ -21,6 +25,7 @@ def create_app() -> FastAPI:
     app.state.limiter = limiter
     app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
     app.add_middleware(SlowAPIMiddleware)
+    app.add_middleware(RequestIDMiddleware)
     app.include_router(health_router, tags=["health"])
     return app
 

--- a/bot_telegram/middlewares/__init__.py
+++ b/bot_telegram/middlewares/__init__.py
@@ -1,0 +1,4 @@
+# Nombre de archivo: __init__.py
+# Ubicación de archivo: bot_telegram/middlewares/__init__.py
+# Descripción: Inicializa el paquete de middlewares del bot
+

--- a/bot_telegram/middlewares/request_id.py
+++ b/bot_telegram/middlewares/request_id.py
@@ -1,0 +1,33 @@
+# Nombre de archivo: request_id.py
+# Ubicación de archivo: bot_telegram/middlewares/request_id.py
+# Descripción: Middleware que genera request_id y captura tg_user_id para logging
+
+import uuid
+
+from aiogram import BaseMiddleware
+from aiogram.types import Update
+
+from core.logging import request_id_var, tg_user_id_var
+
+
+class RequestContextMiddleware(BaseMiddleware):
+    """Asigna `request_id` y `tg_user_id` usando contextvars."""
+
+    async def __call__(self, handler, event: Update, data: dict):
+        request_id = str(uuid.uuid4())
+        token_req = request_id_var.set(request_id)
+
+        tg_user_id = None
+        if getattr(event, "message", None):
+            tg_user_id = event.message.from_user.id
+        elif getattr(event, "callback_query", None):
+            tg_user_id = event.callback_query.from_user.id
+        token_user = tg_user_id_var.set(str(tg_user_id) if tg_user_id is not None else "-")
+
+        data["request_id"] = request_id
+        try:
+            return await handler(event, data)
+        finally:
+            request_id_var.reset(token_req)
+            tg_user_id_var.reset(token_user)
+

--- a/bot_telegram/requirements.txt
+++ b/bot_telegram/requirements.txt
@@ -6,3 +6,4 @@ aiogram==3.13.1
 pandas==2.2.2
 openpyxl==3.1.2
 python-docx==0.8.11
+orjson==3.10.3

--- a/core/logging.py
+++ b/core/logging.py
@@ -1,0 +1,70 @@
+# Nombre de archivo: logging.py
+# Ubicación de archivo: core/logging.py
+# Descripción: Configuración centralizada de logging en formato JSON y variables de contexto
+
+import contextvars
+import logging
+from datetime import datetime
+from typing import Any, Dict
+
+import orjson
+
+# Variables de contexto accesibles por los middlewares y el formatter
+request_id_var: contextvars.ContextVar[str] = contextvars.ContextVar("request_id", default="-")
+tg_user_id_var: contextvars.ContextVar[str] = contextvars.ContextVar("tg_user_id", default="-")
+
+
+class JsonFormatter(logging.Formatter):
+    """Formatter que serializa los registros en formato JSON."""
+
+    def __init__(self, service: str) -> None:
+        super().__init__()
+        self.service = service
+        self._base_fields = {
+            "name",
+            "msg",
+            "args",
+            "levelname",
+            "levelno",
+            "pathname",
+            "filename",
+            "module",
+            "exc_info",
+            "exc_text",
+            "stack_info",
+            "lineno",
+            "funcName",
+            "created",
+            "msecs",
+            "relativeCreated",
+            "thread",
+            "threadName",
+            "processName",
+            "process",
+        }
+
+    def format(self, record: logging.LogRecord) -> str:  # type: ignore[override]
+        message = record.getMessage()
+        log: Dict[str, Any] = {
+            "timestamp": datetime.utcnow().isoformat(),
+            "level": record.levelname,
+            "service": self.service,
+            "message": message,
+            "action": getattr(record, "action", message),
+            "tg_user_id": getattr(record, "tg_user_id", tg_user_id_var.get()),
+            "request_id": getattr(record, "request_id", request_id_var.get()),
+        }
+        for key, value in record.__dict__.items():
+            if key not in self._base_fields and key not in log:
+                log[key] = value
+        return orjson.dumps(log).decode()
+
+
+def configure_logging(service: str) -> None:
+    """Configura logging básico con salida JSON."""
+    handler = logging.StreamHandler()
+    handler.setFormatter(JsonFormatter(service))
+    root = logging.getLogger()
+    root.handlers = [handler]
+    root.setLevel(logging.INFO)
+

--- a/core/middlewares.py
+++ b/core/middlewares.py
@@ -1,0 +1,30 @@
+# Nombre de archivo: middlewares.py
+# Ubicación de archivo: core/middlewares.py
+# Descripción: Middlewares compartidos para los servicios FastAPI
+
+import uuid
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.types import ASGIApp
+
+from core.logging import request_id_var
+
+
+class RequestIDMiddleware(BaseHTTPMiddleware):
+    """Genera y propaga un identificador de solicitud."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        super().__init__(app)
+
+    async def dispatch(self, request: Request, call_next):
+        request_id = str(uuid.uuid4())
+        request.state.request_id = request_id
+        token = request_id_var.set(request_id)
+        try:
+            response = await call_next(request)
+        finally:
+            request_id_var.reset(token)
+        response.headers["X-Request-ID"] = request_id
+        return response
+

--- a/docs/api.md
+++ b/docs/api.md
@@ -47,3 +47,8 @@
 
 - **Variable:** `API_RATE_LIMIT` (por defecto `60/minute`).
 - **Descripción:** Limita la cantidad de solicitudes que puede realizar un mismo origen. Si se supera el límite, el servicio responde con `429 Too Many Requests`.
+
+## Logging y `request_id`
+
+- Cada solicitud genera un encabezado `X-Request-ID` y se propaga en los logs.
+- Los registros se emiten en formato JSON con los campos `service`, `action`, `tg_user_id` y `request_id` para facilitar la trazabilidad.

--- a/docs/bot.md
+++ b/docs/bot.md
@@ -27,6 +27,11 @@ Probar /ping y /help.
 
 Los intentos de acceso de usuarios no incluidos en `TELEGRAM_ALLOWED_IDS` generan un log `acceso_denegado` con el `tg_user_id` y se responde "Acceso no autorizado" al remitente.
 
+## Logging y `request_id`
+
+- Cada actualización del bot genera un `request_id` único que se adjunta a los logs.
+- La salida de `logging` está en formato JSON con los campos `service`, `action`, `tg_user_id` y `request_id`.
+
 ## Clasificación de intención
 
 Cada mensaje de texto se envía al microservicio `nlp_intent` para determinar si es una **Consulta**, una **Acción** u **Otros**.
@@ -107,5 +112,3 @@ Para un diagnóstico rápido está disponible `/diag`, que muestra los contadore
 commands_sla: X | callbacks_sla: Y
 commands_rep: A | callbacks_rep: B
 ```
-
-Los registros (`logging`) incluyen `route`, `cmd` o `data`, y `tg_user_id` para facilitar el seguimiento.

--- a/docs/nlp/intent.md
+++ b/docs/nlp/intent.md
@@ -75,3 +75,8 @@ Si `confidence < INTENT_THRESHOLD`, el bot pedirá una aclaración al usuario pa
 
 - **Variable:** `NLP_RATE_LIMIT` (por defecto `60/minute`).
 - **Descripción:** Controla cuántas clasificaciones puede hacer una misma IP en un período dado. Al excederlo, se responde con `429 Too Many Requests`.
+
+## Logging y `request_id`
+
+- Cada solicitud genera un encabezado `X-Request-ID` y se registra en los logs.
+- Los logs se emiten en formato JSON con los campos `service`, `action`, `tg_user_id` y `request_id`.

--- a/nlp_intent/app/main.py
+++ b/nlp_intent/app/main.py
@@ -14,12 +14,17 @@ from slowapi.errors import RateLimitExceeded
 from .schemas import IntentRequest, IntentResponse
 from .service import classify_text
 from .metrics import metrics
+from core.logging import configure_logging
+from core.middlewares import RequestIDMiddleware
+
+configure_logging("nlp_intent")
 
 limiter = Limiter(key_func=get_remote_address)
 app = FastAPI(title="nlp_intent")
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 app.add_middleware(SlowAPIMiddleware)
+app.add_middleware(RequestIDMiddleware)
 
 
 @app.middleware("http")

--- a/tests/test_request_context_middleware.py
+++ b/tests/test_request_context_middleware.py
@@ -1,0 +1,27 @@
+# Nombre de archivo: test_request_context_middleware.py
+# Ubicación de archivo: tests/test_request_context_middleware.py
+# Descripción: Prueba el middleware de contexto de aiogram
+
+import asyncio
+import types
+import uuid
+
+from bot_telegram.middlewares.request_id import RequestContextMiddleware
+from core.logging import request_id_var, tg_user_id_var
+
+
+def test_request_context_middleware_assigns_ids():
+    middleware = RequestContextMiddleware()
+
+    user = types.SimpleNamespace(id=123)
+    message = types.SimpleNamespace(from_user=user)
+    event = types.SimpleNamespace(message=message, callback_query=None)
+
+    async def handler(event, data):
+        return request_id_var.get(), tg_user_id_var.get(), data["request_id"]
+
+    req_id_ctx, tg_id_ctx, req_id_data = asyncio.run(middleware(handler, event, {}))
+    uuid.UUID(req_id_ctx)
+    assert tg_id_ctx == "123"
+    assert req_id_ctx == req_id_data
+

--- a/tests/test_request_id.py
+++ b/tests/test_request_id.py
@@ -1,0 +1,29 @@
+# Nombre de archivo: test_request_id.py
+# Ubicación de archivo: tests/test_request_id.py
+# Descripción: Verifica que los servicios FastAPI generen X-Request-ID
+
+import uuid
+
+from fastapi.testclient import TestClient
+
+from api.app.main import app as api_app
+from nlp_intent.app.main import app as nlp_app
+
+
+def _assert_request_id(client: TestClient, path: str) -> None:
+    resp = client.get(path)
+    assert resp.status_code == 200
+    header = resp.headers.get("X-Request-ID")
+    assert header is not None
+    uuid.UUID(header)
+
+
+def test_request_id_api() -> None:
+    client = TestClient(api_app)
+    _assert_request_id(client, "/health")
+
+
+def test_request_id_nlp_intent() -> None:
+    client = TestClient(nlp_app)
+    _assert_request_id(client, "/health")
+


### PR DESCRIPTION
## Resumen
- Logging centralizado en formato JSON con `service`, `action`, `tg_user_id` y `request_id`
- Middlewares para generar `request_id` en FastAPI y aiogram
- Pruebas y documentación actualizadas

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a7997905b083308d9ea56085e8b696