### PR TITLE
docs: agregar guías de infraestructura, seguridad y plan web

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Automatizaciones operativas para Metrotel: generación de informes, asistente co
 - **Interfaces**
 
   - **Telegram Bot** (primer canal de operación, con menú accesible por `/menu` o por intención). Incluye los flujos `/repetitividad` y `/sla` y un teclado opcional con atajos a ambos comandos. Ver [docs/bot.md](docs/bot.md) para guía rápida.
-  - **Web Panel** (autenticación simple, accesible por IP interna .28).
+  - **Web Panel** (autenticación simple, accesible por IP interna .28). Ver [docs/web.md](docs/web.md) para el plan del módulo.
   - **nlp_intent** (microservicio NLP para clasificación de intención).
   - CLI opcional para utilidades.
 
@@ -168,7 +168,7 @@ MAPS_LIGHTWEIGHT=true
 
 ## 🛥️ Despliegue
 
-Se recomienda **docker-compose** desde el inicio para reproducibilidad.
+Se recomienda **docker-compose** desde el inicio para reproducibilidad. Los detalles de redes, puertos y volúmenes están en [docs/infra.md](docs/infra.md).
 
 **Requisitos (Debian 12.4)**
 
@@ -211,6 +211,7 @@ La base de datos PostgreSQL no publica su puerto en el host; se expone únicamen
 - Tokens rotados.
 - Usuario DB de mínimos privilegios (incluye cuenta de solo lectura).
 - Rate limiting configurable en API y nlp_intent.
+- Políticas detalladas en [docs/security.md](docs/security.md).
 ---
 
 ## 🧠 Agente autónomo (futuro)

--- a/docs/infra.md
+++ b/docs/infra.md
@@ -1,0 +1,20 @@
+# Nombre de archivo: infra.md
+# Ubicación de archivo: docs/infra.md
+# Descripción: Detalle de las redes, puertos y volúmenes del stack dockerizado
+
+## Redes
+
+- `lasfocas_net`: red bridge interna que conecta todos los servicios. Limita la exposición externa y permite la comunicación directa entre contenedores.
+
+## Puertos
+
+- `postgres` expone `5432` solo a la red interna mediante `expose`.
+- `api` publica `8000:8000` para acceso HTTP desde el host.
+- `nlp_intent` expone `8100` únicamente a la red interna.
+- `pgadmin` (perfil opcional) publica `5050:80` para administración de PostgreSQL.
+
+## Volúmenes
+
+- `postgres_data`: persiste los datos de la base en `/var/lib/postgresql/data`.
+- `bot_data`: almacena archivos y estados del bot en `/app/data`.
+- `./db/init.sql` se monta de forma de solo lectura para inicializar la base.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,20 @@
+# Nombre de archivo: security.md
+# Ubicación de archivo: docs/security.md
+# Descripción: Políticas de manejo de secrets, rate limiting y mínimo privilegio
+
+## Secrets
+
+- Las credenciales se gestionan mediante variables de entorno definidas en `.env` y no se versionan.
+- Para producción se recomienda migrar a **Docker Secrets** o gestores como Vault.
+- No se deben exponer tokens ni contraseñas en logs ni commits.
+
+## Rate limiting
+
+- Cada servicio debe definir límites de solicitudes por origen. Ejemplo: `API_RATE_LIMIT=60/minute`.
+- Superar el límite genera respuestas `429 Too Many Requests` para proteger recursos.
+
+## Principio de mínimo privilegio
+
+- Los contenedores deben ejecutarse con usuarios no root cuando sea posible.
+- La base de datos utiliza usuarios específicos por servicio y roles de solo lectura cuando aplique.
+- Los puertos publicados al host se restringen únicamente a los necesarios.

--- a/docs/web.md
+++ b/docs/web.md
@@ -1,0 +1,32 @@
+# Nombre de archivo: web.md
+# Ubicación de archivo: docs/web.md
+# Descripción: Plan del panel web con autenticación básica
+
+## Objetivo
+
+Proveer una interfaz web interna para ejecutar tareas y visualizar informes generados por la API.
+
+## Stack propuesto
+
+- **FastAPI** con plantillas Jinja2 para renderizado de páginas.
+- Servidor **Uvicorn** detrás de un proxy opcional.
+- Consumo de la API interna mediante llamadas HTTP.
+
+## Rutas iniciales
+
+- `GET /` → redirige a `/login` si no hay sesión.
+- `GET /login` → muestra formulario de acceso.
+- `POST /login` → valida credenciales y crea cookie de sesión.
+- `GET /dashboard` → menú principal con enlaces a informes y acciones.
+
+## Autenticación
+
+- Credenciales básicas definidas en variables de entorno (`WEB_USER`, `WEB_PASS`).
+- Cookies firmadas para mantener la sesión activa.
+- Futuro: integrar SSO interno y gestión de roles.
+
+## Tareas pendientes
+
+- Definir diseño mínimo responsivo.
+- Incorporar permisos por rol cuando se amplíe el sistema.
+- Integrar generación y descarga de informes.


### PR DESCRIPTION
## Resumen
- documentar redes, puertos y volúmenes del stack dockerizado
- definir políticas de manejo de secrets, rate limiting y mínimo privilegio
- describir el plan inicial del panel web y vincular la documentación

## Pruebas
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a79bb42d9c833087ecdf2ec6df16f0