### PR TITLE
[deploy] Agregar red a bot

### DIFF
--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -84,6 +84,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 12
+    networks:
+      - lasfocas_net
 
   # (Opcional) pgAdmin. Levantar con: docker compose -f deploy/compose.yml --profile pgadmin up -d
   pgadmin:


### PR DESCRIPTION
## Resumen
- Agregar seccion de red para el servicio del bot en docker compose

## Pruebas
- `docker compose -f deploy/compose.yml up -d --build` (falló: command not found)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a79ebf9ae4833089e05f053f6af3c4