### PR TITLE
[ci] Añadir workflow de pruebas y lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+# Nombre de archivo: ci.yml
+# Ubicación de archivo: .github/workflows/ci.yml
+# Descripción: Ejecución de pruebas y linting en cada push o pull request
+
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Configurar Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Instalar dependencias
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Ejecutar pytest
+        run: pytest
+      - name: Ejecutar ruff
+        run: ruff check .

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ La base de datos PostgreSQL no publica su puerto en el host; se expone únicamen
 
 ## 📪 CI/CD
 
-**CI (Integración Continua):** test, lint, build docker en cada push/PR.\
+**CI (Integración Continua):** `pytest` y `ruff` se ejecutan en cada push o pull request mediante [GitHub Actions](docs/ci.md).\
 **CD (Entrega Continua):** despliegue automático opcional.
 
 ---

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,14 @@
+# Nombre de archivo: ci.md
+# Ubicación de archivo: docs/ci.md
+# Descripción: Detalle del flujo de integración continua con GitHub Actions
+
+## Flujo de CI
+
+El proyecto ejecuta un flujo de **integración continua** mediante GitHub Actions. Este flujo se activa en cada **push** y **pull request** e incluye los siguientes pasos:
+
+1. **Checkout** del repositorio.
+2. **Instalación de dependencias** definidas en `requirements.txt`.
+3. Ejecución de las **pruebas** con `pytest`.
+4. Análisis de estilo y calidad de código con **`ruff`**.
+
+La finalidad es garantizar que el código pase las pruebas automatizadas y cumpla las reglas de estilo antes de integrarse en la rama principal.

--- a/modules/common/libreoffice_export.py
+++ b/modules/common/libreoffice_export.py
@@ -45,7 +45,7 @@ def convert_to_pdf(docx_path: str, soffice_bin: str) -> str:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
-    except FileNotFoundError as exc:  # pragma: no cover - logging
+    except FileNotFoundError:  # pragma: no cover - logging
         logger.exception(
             "action=convert_to_pdf error=soffice_no_encontrado path=%s", soffice_bin
         )

--- a/modules/informes_repetitividad/processor.py
+++ b/modules/informes_repetitividad/processor.py
@@ -3,7 +3,6 @@
 # Descripción: Funciones de carga, normalización y cálculo de repetitividad
 
 import logging
-from typing import Optional
 
 import pandas as pd
 

--- a/nlp_intent/tests/test_intent.py
+++ b/nlp_intent/tests/test_intent.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import asyncio
 
-import pytest
 import pathlib
 import sys
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ sqlalchemy==2.0.32  # ORM para interactuar con la base de datos
 psycopg[binary]==3.1.19  # Driver PostgreSQL en formato binario
 orjson==3.10.3  # Serializador JSON de alto rendimiento
 slowapi==0.1.9  # Limitador de tasa para FastAPI
+ruff==0.12.7  # Linter para mantener calidad de código


### PR DESCRIPTION
## Resumen
- Configurar GitHub Actions para ejecutar `pytest` y `ruff` en pushes y PRs
- Documentar el flujo de CI y enlazar desde README
- Corregir problemas de lint y fijar `ruff` como dependencia

## Pruebas
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7a07cd71c83309ea27eb95c45b517