### PR TITLE
[web] Servicio web inicial y documentación

### DIFF
--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -51,6 +51,22 @@ services:
     networks:
       - lasfocas_net
 
+  web:
+    build:
+      context: ./web
+      dockerfile: Dockerfile
+    container_name: lasfocas-web
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8080/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+    networks:
+      - lasfocas_net
+
   nlp_intent:
     build:
       context: ..

--- a/docs/web.md
+++ b/docs/web.md
@@ -19,6 +19,15 @@ Proveer una interfaz web interna para ejecutar tareas y visualizar informes gene
 - `POST /login` → valida credenciales y crea cookie de sesión.
 - `GET /dashboard` → menú principal con enlaces a informes y acciones.
 
+## Servicio base implementado
+
+El repositorio incluye un microservicio inicial en `web/main.py` que utiliza **FastAPI** y expone dos rutas básicas:
+
+- `GET /` devuelve un mensaje de bienvenida.
+- `GET /health` responde con `{"status": "ok"}` para verificaciones de salud.
+
+Este servicio se construye con `web/Dockerfile` sobre la imagen `python:3.11-slim` y se despliega mediante `deploy/compose.yml` como servicio `web`, publicando el puerto `8080` al host.
+
 ## Autenticación
 
 - Credenciales básicas definidas en variables de entorno (`WEB_USER`, `WEB_PASS`).

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,16 @@
+# Nombre de archivo: Dockerfile
+# Ubicación de archivo: web/Dockerfile
+# Descripción: Construye el contenedor para el servicio web
+
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir fastapi==0.110.1 uvicorn[standard]==0.29.0 \
+    && useradd -ms /bin/bash appuser
+
+COPY . /app
+
+USER appuser
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/web/main.py
+++ b/web/main.py
@@ -1,0 +1,28 @@
+# Nombre de archivo: main.py
+# Ubicación de archivo: web/main.py
+# Descripción: Servicio FastAPI básico para el módulo web
+
+"""Módulo principal del servicio web de LAS-FOCAS."""
+
+from fastapi import FastAPI
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("web")
+
+app = FastAPI(title="Servicio Web LAS-FOCAS")
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    """Verifica que el servicio esté disponible."""
+    logger.info("Chequeo de salud del servicio web")
+    return {"status": "ok"}
+
+
+@app.get("/")
+async def read_root() -> dict[str, str]:
+    """Retorna un mensaje inicial."""
+    logger.info("Solicitud recibida en la ruta raíz")
+    return {"message": "Hola desde el servicio web"}
+


### PR DESCRIPTION
## Resumen
- se crea el módulo `web/` con un servicio FastAPI mínimo
- se agrega la definición del servicio `web` en `deploy/compose.yml`
- se documenta el servicio web y su despliegue en `docs/web.md`

## Pruebas
- `ruff check web/main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7a267da7c8330aa6c1a09c59168a3