### PR TITLE
[deploy] Agrega LibreOffice a imagen del bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ API_RATE_LIMIT=60/minute
 NLP_RATE_LIMIT=60/minute
 ```
 
+La imagen del servicio `bot` incluye LibreOffice, por lo que al definir
+`SOFFICE_BIN=/usr/bin/soffice` se habilita la exportación de informes a PDF.
+
 ---
 
 ## 🗳️ Logging & Métricas

--- a/deploy/docker/bot.Dockerfile
+++ b/deploy/docker/bot.Dockerfile
@@ -9,6 +9,11 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
+# Instalación de LibreOffice para exportar informes a PDF
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libreoffice \
+    && rm -rf /var/lib/apt/lists/*
+
 # Instalación de dependencias del bot
 COPY bot_telegram/requirements.txt /app/bot_requirements.txt
 RUN pip install --no-cache-dir -r /app/bot_requirements.txt

--- a/docs/bot.md
+++ b/docs/bot.md
@@ -10,6 +10,10 @@
 
 La imagen del bot copia los directorios `bot_telegram`, `modules` y `core` para
 que los flujos `/sla` y `/repetitividad` funcionen correctamente.
+
+La imagen incluye LibreOffice en modo headless, lo que permite convertir los
+reportes a PDF siempre que se defina `SOFFICE_BIN=/usr/bin/soffice` en el
+entorno.
 ```bash
 docker compose -f deploy/compose.yml up -d --build bot
 docker compose -f deploy/compose.yml logs -f bot

--- a/docs/informes/repetitividad.md
+++ b/docs/informes/repetitividad.md
@@ -32,6 +32,6 @@
 - `REP_TEMPLATE_PATH=/app/templates/repetitividad.docx` ruta de la plantilla.
 - `REPORTS_DIR=/app/data/reports` destino de los informes.
 - `UPLOADS_DIR=/app/data/uploads` ubicación temporal de archivos subidos.
-- `SOFFICE_BIN=/usr/bin/soffice` para habilitar la conversión a PDF (opcional).
+- `SOFFICE_BIN=/usr/bin/soffice` habilita la conversión a PDF. LibreOffice ya está instalado en la imagen del bot.
 - `MAPS_ENABLED=false` habilita mapas cuando es `true`.
 - `MAPS_LIGHTWEIGHT=true` usa Matplotlib sin stack geoespacial.

--- a/docs/informes/sla.md
+++ b/docs/informes/sla.md
@@ -47,5 +47,5 @@ Mapeos admitidos: `TicketID`→`ID`, `Apertura`→`FECHA_APERTURA`, `Cierre`→`
 - `SLA_TEMPLATE_PATH=/app/templates/sla.docx` ruta de la plantilla.
 - `REPORTS_DIR=/app/data/reports` destino de los informes.
 - `UPLOADS_DIR=/app/data/uploads` ubicación temporal de archivos subidos.
-- `SOFFICE_BIN=/usr/bin/soffice` para habilitar PDF (opcional).
+- `SOFFICE_BIN=/usr/bin/soffice` habilita la exportación a PDF. LibreOffice ya está instalado en la imagen del bot.
 - `WORK_HOURS=true` habilita cálculo de TTR en horario laboral (placeholder).


### PR DESCRIPTION
## Resumen
- instala LibreOffice en la imagen del bot para generar PDF
- documenta la presencia de LibreOffice y cómo habilitar la conversión a PDF

## Pruebas
- `pytest -q`
- ❌ `docker build -f deploy/docker/bot.Dockerfile -t lasfocas-bot:test .` (docker no disponible)


------
https://chatgpt.com/codex/tasks/task_e_68a8b9d110a8833096c429bf952f59df