### PR TITLE
[db] Configuración de Alembic y migración inicial

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,43 @@
+# Nombre de archivo: alembic.ini
+# Ubicación de archivo: alembic.ini
+# Descripción: Configuración de Alembic para migraciones de base de datos
+
+[alembic]
+script_location = db/migrations
+prepend_sys_path = .
+
+# La URL se define a partir de variables de entorno en db/migrations/env.py
+sqlalchemy.url =
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/db/migrations/README
+++ b/db/migrations/README
@@ -1,0 +1,5 @@
+# Nombre de archivo: README
+# Ubicación de archivo: db/migrations/README
+# Descripción: Descripción del entorno de migraciones de Alembic
+
+Este directorio contiene la configuración y los scripts de Alembic que permiten versionar el esquema de la base de datos.

--- a/db/migrations/env.py
+++ b/db/migrations/env.py
@@ -1,0 +1,64 @@
+# Nombre de archivo: env.py
+# Ubicación de archivo: db/migrations/env.py
+# Descripción: Configuración del contexto de migraciones de Alembic
+
+from logging.config import fileConfig
+import os
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+# Objeto de configuración de Alembic
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# Construir la URL de conexión desde variables de entorno
+_db_user = os.getenv("POSTGRES_USER", "lasfocas")
+_db_password = os.getenv("POSTGRES_PASSWORD", "lasfocas")
+_db_host = os.getenv("POSTGRES_HOST", "localhost")
+_db_port = os.getenv("POSTGRES_PORT", "5432")
+_db_name = os.getenv("POSTGRES_DB", "lasfocas")
+
+config.set_main_option(
+    "sqlalchemy.url",
+    f"postgresql+psycopg://{_db_user}:{_db_password}@{_db_host}:{_db_port}/{_db_name}",
+)
+
+# Metadatos objetivo para autogeneración
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+# Al no contar con modelos ORM se deja en None
+
+
+# pylint: disable=unused-argument
+# Alembic requiere estas funciones con firmas específicas
+
+def run_migrations_offline() -> None:
+    """Ejecutar migraciones en modo offline."""
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(url=url, literal_binds=True, dialect_opts={"paramstyle": "named"})
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Ejecutar migraciones en modo online."""
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/db/migrations/script.py.mako
+++ b/db/migrations/script.py.mako
@@ -1,0 +1,31 @@
+<%doc>
+# Nombre de archivo: script.py.mako
+# Ubicación de archivo: db/migrations/script.py.mako
+# Descripción: Plantilla para generar revisiones de Alembic
+</%doc>
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/db/migrations/versions/0001_estructura_inicial.py
+++ b/db/migrations/versions/0001_estructura_inicial.py
@@ -1,0 +1,33 @@
+# Nombre de archivo: 0001_estructura_inicial.py
+# Ubicación de archivo: db/migrations/versions/0001_estructura_inicial.py
+# Descripción: Migración inicial que aplica el esquema base
+
+"""estructura inicial
+
+Revision ID: 0001
+Revises:
+Create Date: 2025-08-22 19:10:47.732795
+
+"""
+from typing import Sequence, Union
+from alembic import op
+import pathlib
+
+# Identificadores de revisión de Alembic
+revision: str = '0001'
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Crear esquema inicial desde db/init.sql."""
+    sql_path = pathlib.Path(__file__).resolve().parents[2] / "db" / "init.sql"
+    with open(sql_path, "r", encoding="utf-8") as sql_file:
+        op.execute(sql_file.read())
+
+
+def downgrade() -> None:
+    """Eliminar esquema y usuario creados en la migración."""
+    op.execute("DROP SCHEMA IF EXISTS app CASCADE;")
+    op.execute("DROP USER IF EXISTS lasfocas_readonly;")

--- a/docs/db.md
+++ b/docs/db.md
@@ -26,3 +26,15 @@ El script `db/init.sql` crea el usuario `lasfocas_readonly` con permisos restrin
 - Acceso `SELECT` sobre todas las tablas del esquema `app`.
 
 Este usuario permite realizar consultas y dashboards sin riesgo de modificación de datos.
+
+## Migraciones con Alembic
+
+Las migraciones del esquema se gestionan con **Alembic**. La configuración principal se encuentra en `alembic.ini` y los scripts se almacenan en `db/migrations`.
+
+Pasos básicos para trabajar con migraciones:
+
+1. Generar una revisión: `alembic revision -m "descripcion"`.
+2. Editar el archivo creado en `db/migrations/versions/` agregando el encabezado requerido y las operaciones deseadas.
+3. Aplicar los cambios: `alembic upgrade head`.
+
+La revisión inicial ejecuta el contenido de `db/init.sql`, creando el esquema `app` junto con el usuario de solo lectura.

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ pytest==8.3.2  # Marco de pruebas
 httpx==0.27.0  # Cliente HTTP asíncrono
 sqlalchemy==2.0.32  # ORM para interactuar con la base de datos
 psycopg[binary]==3.1.19  # Driver PostgreSQL en formato binario
+alembic==1.13.1  # Herramienta de migraciones para SQLAlchemy
 orjson==3.10.3  # Serializador JSON de alto rendimiento
 slowapi==0.1.9  # Limitador de tasa para FastAPI
 ruff==0.12.7  # Linter para mantener calidad de código


### PR DESCRIPTION
## Resumen
- Añade Alembic al proyecto y configura entorno de migraciones
- Crea revisión inicial que ejecuta el esquema definido en `db/init.sql`
- Documenta el flujo de migraciones en `docs/db.md`

## Testing
- `alembic upgrade head` *(falla: connection refused)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8c036f49c8330a87b542ed69c8656