### PR TITLE
[web] Añadir autenticación básica y pruebas

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -35,3 +35,7 @@ MAPS_LIGHTWEIGHT=true
 # Rate limiting
 API_RATE_LIMIT=60/minute
 NLP_RATE_LIMIT=60/minute
+
+# Web Panel
+WEB_USERNAME=admin
+WEB_PASSWORD=changeme

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Automatizaciones operativas para Metrotel: generación de informes, asistente co
 - **Interfaces**
 
   - **Telegram Bot** (primer canal de operación, con menú accesible por `/menu` o por intención). Incluye los flujos `/repetitividad` y `/sla` y un teclado opcional con atajos a ambos comandos. Ver [docs/bot.md](docs/bot.md) para guía rápida.
-  - **Web Panel** (autenticación simple, accesible por IP interna .28). Ver [docs/web.md](docs/web.md) para el plan del módulo.
+  - **Web Panel** (autenticación simple vía `WEB_USERNAME`/`WEB_PASSWORD`, accesible por IP interna .28). Ver [docs/web.md](docs/web.md) para el plan del módulo.
   - **nlp_intent** (microservicio NLP para clasificación de intención).
   - CLI opcional para utilidades.
 
@@ -39,7 +39,7 @@ Automatizaciones operativas para Metrotel: generación de informes, asistente co
 - **Autenticación**
 
   - **Allowlist de IDs de Telegram** para uso del bot.
-  - **Web:** usuario/contraseña (básico al inicio; SSO interno a futuro).
+  - **Web:** usuario/contraseña configurables con `WEB_USERNAME` y `WEB_PASSWORD` (básico al inicio; SSO interno a futuro).
 
 ---
 

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -57,6 +57,8 @@ services:
       dockerfile: Dockerfile
     container_name: lasfocas-web
     restart: unless-stopped
+    env_file:
+      - .env
     ports:
       - "8080:8080"
     healthcheck:

--- a/deploy/env.sample
+++ b/deploy/env.sample
@@ -35,3 +35,7 @@ MAPS_LIGHTWEIGHT=true
 # Rate limiting
 API_RATE_LIMIT=60/minute
 NLP_RATE_LIMIT=60/minute
+
+# Web Panel
+WEB_USERNAME=admin
+WEB_PASSWORD=changeme

--- a/docs/web.md
+++ b/docs/web.md
@@ -30,7 +30,7 @@ Este servicio se construye con `web/Dockerfile` sobre la imagen `python:3.11-sli
 
 ## Autenticación
 
-- Credenciales básicas definidas en variables de entorno (`WEB_USER`, `WEB_PASS`).
+- Credenciales básicas definidas en variables de entorno (`WEB_USERNAME`, `WEB_PASSWORD`).
 - Cookies firmadas para mantener la sesión activa.
 - Futuro: integrar SSO interno y gestión de roles.
 

--- a/tests/test_web_auth.py
+++ b/tests/test_web_auth.py
@@ -1,0 +1,47 @@
+# Nombre de archivo: test_web_auth.py
+# Ubicación de archivo: tests/test_web_auth.py
+# Descripción: Pruebas para la autenticación básica del servicio web
+
+"""Verifica el acceso al servicio web bajo autenticación básica."""
+
+from pathlib import Path
+import importlib
+import os
+import sys
+
+from fastapi.testclient import TestClient
+
+# Agrega la ruta del módulo web al path de importación
+sys.path.append(str(Path(__file__).resolve().parents[1] / "web"))
+
+
+def get_client(username: str, password: str) -> TestClient:
+    """Crea un cliente de pruebas con credenciales específicas."""
+    os.environ["WEB_USERNAME"] = username
+    os.environ["WEB_PASSWORD"] = password
+    module = importlib.reload(importlib.import_module("main"))
+    return TestClient(module.app)
+
+
+def test_denied_without_credentials() -> None:
+    """El acceso sin credenciales debe ser rechazado."""
+    client = get_client("user", "pass")
+    response = client.get("/")
+    assert response.status_code == 401
+
+
+def test_authorized_access() -> None:
+    """Con credenciales válidas se permite el acceso."""
+    client = get_client("user", "pass")
+    response = client.get("/", auth=("user", "pass"))
+    assert response.status_code == 200
+    data = response.json()
+    assert data["message"] == "Hola desde el servicio web"
+
+
+def test_denied_with_invalid_credentials() -> None:
+    """El uso de credenciales incorrectas devuelve 401."""
+    client = get_client("user", "pass")
+    response = client.get("/", auth=("user", "wrong"))
+    assert response.status_code == 401
+

--- a/web/main.py
+++ b/web/main.py
@@ -4,13 +4,63 @@
 
 """Módulo principal del servicio web de LAS-FOCAS."""
 
-from fastapi import FastAPI
+import base64
 import logging
+import os
+from fastapi import FastAPI, Request, Response, status
+from starlette.middleware.base import BaseHTTPMiddleware
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("web")
 
+
+class BasicAuthMiddleware(BaseHTTPMiddleware):
+    """Aplica autenticación HTTP básica basada en variables de entorno."""
+
+    def __init__(self, app: FastAPI) -> None:
+        super().__init__(app)
+        self.username = os.getenv("WEB_USERNAME", "")
+        self.password = os.getenv("WEB_PASSWORD", "")
+        if not self.username or not self.password:
+            logger.warning(
+                "Variables WEB_USERNAME/WEB_PASSWORD no configuradas; el acceso quedará bloqueado"
+            )
+
+    async def dispatch(self, request: Request, call_next):
+        if request.url.path == "/health":
+            return await call_next(request)
+
+        auth = request.headers.get("Authorization")
+        if not auth or not auth.startswith("Basic "):
+            logger.warning("Solicitud no autorizada sin credenciales")
+            return Response(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                headers={"WWW-Authenticate": "Basic"},
+            )
+
+        try:
+            decoded = base64.b64decode(auth.split(" ")[1]).decode("utf-8")
+            user, pwd = decoded.split(":", 1)
+        except Exception:  # noqa: BLE001
+            logger.warning("Error al decodificar credenciales básicas")
+            return Response(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                headers={"WWW-Authenticate": "Basic"},
+            )
+
+        if user != self.username or pwd != self.password:
+            logger.warning("Credenciales inválidas para usuario '%s'", user)
+            return Response(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                headers={"WWW-Authenticate": "Basic"},
+            )
+
+        logger.info("Usuario '%s' autorizado", user)
+        return await call_next(request)
+
+
 app = FastAPI(title="Servicio Web LAS-FOCAS")
+app.add_middleware(BasicAuthMiddleware)
 
 
 @app.get("/health")


### PR DESCRIPTION
## Resumen
- agregar middleware de autenticación HTTP básica configurado por WEB_USERNAME/WEB_PASSWORD
- documentar y propagar variables de entorno para el panel web
- crear pruebas para acceso autorizado y denegado del servicio web

## Testing
- `ruff check web/main.py tests/test_web_auth.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8c1e19db083309e0a7f3c310d533a