### PR TITLE
[api] Rate limiting por API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ MAPS_LIGHTWEIGHT=true
 API_RATE_LIMIT=60/minute
 NLP_RATE_LIMIT=60/minute
 ```
+Las solicitudes a la API deben incluir el encabezado `X-API-Key`; el límite se calcula por clave (o por IP si falta).
 
 La imagen del servicio `bot` incluye LibreOffice, por lo que al definir
 `SOFFICE_BIN=/usr/bin/soffice` se habilita la exportación de informes a PDF.

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -2,7 +2,7 @@
 # Ubicación de archivo: api/app/main.py
 # Descripción: Aplicación FastAPI principal con limitación de tasa
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 import os
 from slowapi.middleware import SlowAPIMiddleware
 from slowapi import Limiter, _rate_limit_exceeded_handler
@@ -16,10 +16,14 @@ from core.middlewares import RequestIDMiddleware
 configure_logging("api")
 
 
+def get_api_key_or_ip(request: Request) -> str:
+    """Obtiene la API key del encabezado o la IP si no está presente."""
+    return request.headers.get("X-API-Key") or get_remote_address(request)
+
 def create_app() -> FastAPI:
     """Crea la instancia principal de FastAPI y aplica rate limiting."""
     rate_limit = os.getenv("API_RATE_LIMIT", "60/minute")
-    limiter = Limiter(key_func=get_remote_address, default_limits=[rate_limit])
+    limiter = Limiter(key_func=get_api_key_or_ip, default_limits=[rate_limit])
 
     app = FastAPI(title="LAS-FOCAS API", version="0.1.0")
     app.state.limiter = limiter

--- a/db/init.sql
+++ b/db/init.sql
@@ -33,6 +33,13 @@ CREATE TABLE IF NOT EXISTS app.messages (
     created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW()
 );
 
+-- Tabla de API Keys
+CREATE TABLE IF NOT EXISTS app.api_keys (
+    id SERIAL PRIMARY KEY,
+    api_key TEXT NOT NULL UNIQUE,
+    created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW()
+);
+
 CREATE INDEX IF NOT EXISTS idx_messages_user ON app.messages(tg_user_id);
 CREATE INDEX IF NOT EXISTS idx_messages_created ON app.messages(created_at);
 

--- a/db/migrations/versions/0002_api_keys.py
+++ b/db/migrations/versions/0002_api_keys.py
@@ -1,0 +1,39 @@
+# Nombre de archivo: 0002_api_keys.py
+# Ubicación de archivo: db/migrations/versions/0002_api_keys.py
+# Descripción: Crea la tabla api_keys para gestión de claves de API
+"""tabla api_keys
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2025-08-22 19:10:47.732795
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "0002"
+down_revision: Union[str, None] = "0001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Crear tabla api_keys."""
+    op.create_table(
+        "api_keys",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("api_key", sa.Text, nullable=False, unique=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=False),
+            server_default=sa.text("NOW()"),
+        ),
+        schema="app",
+    )
+
+
+def downgrade() -> None:
+    """Eliminar tabla api_keys."""
+    op.drop_table("api_keys", schema="app")

--- a/docs/api.md
+++ b/docs/api.md
@@ -46,7 +46,8 @@
 ## Rate limiting
 
 - **Variable:** `API_RATE_LIMIT` (por defecto `60/minute`).
-- **Descripción:** Limita la cantidad de solicitudes que puede realizar un mismo origen. Si se supera el límite, el servicio responde con `429 Too Many Requests`.
+- **Clave:** encabezado `X-API-Key`.
+- **Descripción:** Cada clave cuenta con su propio límite. Si no se envía, se utiliza la IP remota. Al superar el límite se responde con `429 Too Many Requests`.
 
 ## Logging y `request_id`
 

--- a/docs/db.md
+++ b/docs/db.md
@@ -27,6 +27,14 @@ El script `db/init.sql` crea el usuario `lasfocas_readonly` con permisos restrin
 
 Este usuario permite realizar consultas y dashboards sin riesgo de modificación de datos.
 
+## Tabla api_keys
+
+Esta tabla almacena las claves de acceso utilizadas por la API.
+Campos:
+- `id`: identificador interno.
+- `api_key`: clave única para autenticar y aplicar rate limiting.
+- `created_at`: fecha de creación.
+
 ## Migraciones con Alembic
 
 Las migraciones del esquema se gestionan con **Alembic**. La configuración principal se encuentra en `alembic.ini` y los scripts se almacenan en `db/migrations`.

--- a/tests/test_rate_limit_api.py
+++ b/tests/test_rate_limit_api.py
@@ -8,18 +8,29 @@ import sys
 
 from fastapi.testclient import TestClient
 
-sys.path.append(str(Path(__file__).resolve().parents[1] / "api"))
-os.environ["API_RATE_LIMIT"] = "2/minute"
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'api'))
+os.environ['API_RATE_LIMIT'] = '2/minute'
 
 from app.main import create_app
 
-app = create_app()
-client = TestClient(app)
+def get_client() -> TestClient:
+    app = create_app()
+    return TestClient(app)
 
+def test_api_rate_limit_por_clave() -> None:
+    """Tras dos solicitudes con la misma clave, la tercera es rechazada."""
+    client = get_client()
+    headers = {'X-API-Key': 'alpha'}
+    assert client.get('/health', headers=headers).status_code == 200
+    assert client.get('/health', headers=headers).status_code == 200
+    assert client.get('/health', headers=headers).status_code == 429
 
-def test_api_rate_limit() -> None:
-    """Tras dos solicitudes, la tercera debe ser rechazada."""
-    assert client.get("/health").status_code == 200
-    assert client.get("/health").status_code == 200
-    response = client.get("/health")
-    assert response.status_code == 429
+def test_api_rate_limit_independiente() -> None:
+    """Superar el límite con una clave no afecta a otra."""
+    client = get_client()
+    headers_a = {'X-API-Key': 'alpha'}
+    headers_b = {'X-API-Key': 'beta'}
+    assert client.get('/health', headers=headers_a).status_code == 200
+    assert client.get('/health', headers=headers_a).status_code == 200
+    assert client.get('/health', headers=headers_a).status_code == 429
+    assert client.get('/health', headers=headers_b).status_code == 200


### PR DESCRIPTION
## Resumen
- Agrega tabla `api_keys` para gestionar claves de acceso
- Aplica limitación de tasa por clave usando SlowAPI
- Documenta uso de encabezado `X-API-Key` y actualiza pruebas

## Pruebas
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8c5aaf03c8330b3e77e778fd849eb