### PR TITLE
[comparador_fo] Añadir runner con pruebas y documentación

### DIFF
--- a/docs/informes/comparador_fo.md
+++ b/docs/informes/comparador_fo.md
@@ -1,0 +1,22 @@
+# Nombre de archivo: comparador_fo.md
+# Ubicación de archivo: docs/informes/comparador_fo.md
+# Descripción: Documentación del comparador de trazas de fibra óptica
+
+## Insumos requeridos
+- Dos archivos de trazas FO en formato binario (`.sor` u otros).
+- Tamaño máximo recomendado: 10MB por archivo.
+
+## Validaciones
+- Ambos archivos deben existir y ser legibles.
+- Los hashes SHA256 permiten detectar diferencias con exactitud.
+
+## Uso básico
+1. Proveer las rutas de los dos archivos a comparar.
+2. El módulo calcula el hash de cada archivo.
+3. Se informa si las trazas son idénticas mediante el campo `iguales`.
+
+## Paths de salida
+- No se generan archivos nuevos; solo se devuelve un diccionario con resultados.
+
+## Variables de entorno
+- Ninguna por el momento.

--- a/modules/comparador_fo/__init__.py
+++ b/modules/comparador_fo/__init__.py
@@ -1,0 +1,7 @@
+# Nombre de archivo: __init__.py
+# Ubicación de archivo: modules/comparador_fo/__init__.py
+# Descripción: Inicializa el módulo de comparador de trazas FO y expone el runner
+
+from .runner import run
+
+__all__ = ["run"]

--- a/modules/comparador_fo/runner.py
+++ b/modules/comparador_fo/runner.py
@@ -1,0 +1,30 @@
+# Nombre de archivo: runner.py
+# Ubicación de archivo: modules/comparador_fo/runner.py
+# Descripción: Compara trazas FO mediante hash SHA256 para verificar diferencias
+
+import hashlib
+import logging
+from typing import Dict
+
+logger = logging.getLogger(__name__)
+
+
+def run(traza_a: str, traza_b: str) -> Dict[str, object]:
+    """Compara dos archivos de trazas FO.
+
+    Calcula el hash SHA256 de cada archivo y determina si son idénticos.
+    """
+    with open(traza_a, "rb") as file_a:
+        data_a = file_a.read()
+    with open(traza_b, "rb") as file_b:
+        data_b = file_b.read()
+
+    hash_a = hashlib.sha256(data_a).hexdigest()
+    hash_b = hashlib.sha256(data_b).hexdigest()
+    iguales = hash_a == hash_b
+
+    logger.info(
+        "action=run hash_a=%s hash_b=%s iguales=%s", hash_a, hash_b, iguales
+    )
+
+    return {"hash_a": hash_a, "hash_b": hash_b, "iguales": iguales}

--- a/tests/test_comparador_fo_runner.py
+++ b/tests/test_comparador_fo_runner.py
@@ -1,0 +1,30 @@
+# Nombre de archivo: test_comparador_fo_runner.py
+# Ubicación de archivo: tests/test_comparador_fo_runner.py
+# Descripción: Pruebas para la función run del comparador de trazas FO
+
+from modules.comparador_fo import run
+
+
+def test_run_detecta_trazas_iguales(tmp_path):
+    archivo_a = tmp_path / "traza_a.txt"
+    archivo_b = tmp_path / "traza_b.txt"
+    contenido = b"traza ejemplo"
+    archivo_a.write_bytes(contenido)
+    archivo_b.write_bytes(contenido)
+
+    resultado = run(str(archivo_a), str(archivo_b))
+
+    assert resultado["iguales"] is True
+    assert resultado["hash_a"] == resultado["hash_b"]
+
+
+def test_run_detecta_trazas_distintas(tmp_path):
+    archivo_a = tmp_path / "traza_a.txt"
+    archivo_b = tmp_path / "traza_b.txt"
+    archivo_a.write_bytes(b"traza 1")
+    archivo_b.write_bytes(b"traza 2")
+
+    resultado = run(str(archivo_a), str(archivo_b))
+
+    assert resultado["iguales"] is False
+    assert resultado["hash_a"] != resultado["hash_b"]


### PR DESCRIPTION
## Resumen
- Agregar módulo `comparador_fo` con runner para comparar trazas FO mediante hashes
- Documentar el uso en `docs/informes/comparador_fo.md`
- Incluir pruebas unitarias para verificar coincidencia y diferencia de trazas

## Testing
- `PYTHONPATH=. pytest tests/test_comparador_fo_runner.py -q`
- `PYTHONPATH=. pytest -q` *(falla: jinja2 must be installed to use Jinja2Templates)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c8334ea88330b4f2a5d0cd1020e5