### PR TITLE
[web] Agrego ruta de login y pruebas

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -26,6 +26,7 @@ El repositorio incluye un microservicio en `web/main.py` que utiliza **FastAPI**
 - `GET /` renderiza `index.html` mostrando el rol del usuario.
 - `GET /health` responde con `{"status": "ok"}` para verificaciones de salud.
 - `GET /admin` accesible solo para usuarios con rol `admin`.
+- `GET /login` entrega un formulario de acceso aún en desarrollo.
 
 Este servicio se construye con `web/Dockerfile` sobre la imagen `python:3.11-slim` y se despliega mediante `deploy/compose.yml` como servicio `web`, publicando el puerto `8080` al host.
 

--- a/tests/test_web_login.py
+++ b/tests/test_web_login.py
@@ -1,0 +1,33 @@
+# Nombre de archivo: test_web_login.py
+# Ubicación de archivo: tests/test_web_login.py
+# Descripción: Pruebas de la ruta /login en el servicio web
+
+"""Verifica que la ruta /login responda sin autenticación."""
+
+from pathlib import Path
+import importlib
+import os
+import sys
+
+from fastapi.testclient import TestClient
+
+# Agrega la ruta del módulo web al path de importación
+sys.path.append(str(Path(__file__).resolve().parents[1] / "web"))
+
+
+def get_client() -> TestClient:
+    """Configura credenciales de prueba y retorna un cliente."""
+    os.environ["WEB_ADMIN_USERNAME"] = "admin"
+    os.environ["WEB_ADMIN_PASSWORD"] = "adminpass"
+    os.environ["WEB_LECTOR_USERNAME"] = "lector"
+    os.environ["WEB_LECTOR_PASSWORD"] = "lectpass"
+    module = importlib.reload(importlib.import_module("main"))
+    return TestClient(module.app)
+
+
+def test_login_accessible_without_auth() -> None:
+    """La ruta /login debe estar disponible sin credenciales."""
+    client = get_client()
+    response = client.get("/login")
+    assert response.status_code == 200
+    assert "Formulario de login pendiente" in response.text

--- a/web/main.py
+++ b/web/main.py
@@ -32,7 +32,7 @@ class BasicAuthMiddleware(BaseHTTPMiddleware):
             )
 
     async def dispatch(self, request: Request, call_next):
-        if request.url.path == "/health":
+        if request.url.path in {"/health", "/login"}:
             return await call_next(request)
 
         auth = request.headers.get("Authorization")
@@ -88,6 +88,18 @@ async def health() -> dict[str, str]:
     """Verifica que el servicio esté disponible."""
     logger.info("Chequeo de salud del servicio web")
     return {"status": "ok"}
+
+
+def login_stub(request: Request) -> HTMLResponse:
+    """Stub temporal que devuelve una página de login básica."""
+    logger.info("Respuesta del stub de login")
+    return templates.TemplateResponse("login.html", {"request": request})
+
+
+@app.get("/login", response_class=HTMLResponse)
+async def login(request: Request) -> HTMLResponse:
+    """Ruta de acceso al formulario de login."""
+    return login_stub(request)
 
 
 @app.get("/", response_class=HTMLResponse)

--- a/web/templates/login.html
+++ b/web/templates/login.html
@@ -1,0 +1,13 @@
+<!-- Nombre de archivo: login.html -->
+<!-- Ubicación de archivo: web/templates/login.html -->
+<!-- Descripción: Formulario básico de inicio de sesión -->
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <title>Login</title>
+</head>
+<body>
+  <h1>Formulario de login pendiente</h1>
+</body>
+</html>


### PR DESCRIPTION
## Resumen
- Permitir acceso libre a `/login` y reutilizar un stub que entrega un formulario básico.
- Añadir plantilla `login.html` y documentación de la nueva ruta.
- Incluir pruebas que validan la accesibilidad de `/login` sin credenciales.

## Pruebas
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8c9a488fc8330800131363cf943aa