### PR TITLE
[config] Añadir variable WORK_HOURS y documentarla

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -31,6 +31,8 @@ UPLOADS_DIR=/app/data/uploads
 SOFFICE_BIN=/usr/bin/soffice
 MAPS_ENABLED=false
 MAPS_LIGHTWEIGHT=true
+# Cálculo de TTR en horario laboral (true) o 24/7 (false)
+WORK_HOURS=false
 
 # Rate limiting
 API_RATE_LIMIT=60/minute

--- a/README.md
+++ b/README.md
@@ -156,11 +156,14 @@ UPLOADS_DIR=/app/data/uploads
 SOFFICE_BIN=/usr/bin/soffice
 MAPS_ENABLED=false
 MAPS_LIGHTWEIGHT=true
+# Cálculo de TTR en horario laboral (true) o 24/7 (false)
+WORK_HOURS=false
 
 # Rate limiting
 API_RATE_LIMIT=60/minute
 NLP_RATE_LIMIT=60/minute
 ```
+La variable `WORK_HOURS` permite ajustar el cálculo del TTR al horario laboral; en `false` se usa el total de horas calendario.
 Las solicitudes a la API deben incluir el encabezado `X-API-Key`; el límite se calcula por clave (o por IP si falta).
 
 La imagen del servicio `bot` incluye LibreOffice, por lo que al definir

--- a/deploy/env.sample
+++ b/deploy/env.sample
@@ -31,6 +31,8 @@ UPLOADS_DIR=/app/data/uploads
 SOFFICE_BIN=/usr/bin/soffice
 MAPS_ENABLED=false
 MAPS_LIGHTWEIGHT=true
+# Cálculo de TTR en horario laboral (true) o 24/7 (false)
+WORK_HOURS=false
 
 # Rate limiting
 API_RATE_LIMIT=60/minute

--- a/docs/informes/sla.md
+++ b/docs/informes/sla.md
@@ -20,6 +20,7 @@ Mapeos admitidos: `TicketID`→`ID`, `Apertura`→`FECHA_APERTURA`, `Cierre`→`
 ## Cálculo
 - Se normalizan las columnas y se calcula `TTR_h = (FECHA_CIERRE - FECHA_APERTURA) / 3600`.
 - Si `WORK_HOURS=true` se aplica un cálculo alternativo de TTR basado en horario laboral (por ahora reducido al 50 % como *placeholder*).
+- Ejemplo: un ticket abierto a las 08:00 y cerrado a las 20:00 computa 6 h de TTR en lugar de 12 h.
 - Se filtra por `FECHA_CIERRE` dentro del período indicado (mes/año).
 - Si falta `SLA_OBJETIVO_HORAS`, se usa `SLA_POR_SERVICIO` con fallback **24 h**.
 - Se excluyen casos sin fecha de cierre y se informa la cantidad excluida.
@@ -48,4 +49,4 @@ Mapeos admitidos: `TicketID`→`ID`, `Apertura`→`FECHA_APERTURA`, `Cierre`→`
 - `REPORTS_DIR=/app/data/reports` destino de los informes.
 - `UPLOADS_DIR=/app/data/uploads` ubicación temporal de archivos subidos.
 - `SOFFICE_BIN=/usr/bin/soffice` habilita la exportación a PDF. LibreOffice ya está instalado en la imagen del bot.
-- `WORK_HOURS=true` habilita cálculo de TTR en horario laboral (placeholder).
+- `WORK_HOURS=false` usa horas calendario; en `true` habilita cálculo de TTR en horario laboral (placeholder).


### PR DESCRIPTION
## Resumen
- se agrega variable `WORK_HOURS` en archivos de ejemplo de entorno
- se documenta su uso en README y en la guía del informe SLA

## Pruebas
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a9ca8e58908330922cba6e39edc996