### PR TITLE
[web] Ajustar logging y middleware de request

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -30,6 +30,10 @@ El repositorio incluye un microservicio en `web/main.py` que utiliza **FastAPI**
 
 Este servicio se construye con `web/Dockerfile` sobre la imagen `python:3.11-slim` y se despliega mediante `deploy/compose.yml` como servicio `web`, publicando el puerto `8080` al host.
 
+## Logging
+
+El servicio inicializa el log mediante `configure_logging("web")`, lo que emite registros en formato JSON con campos `action`, `request_id` y demás metadatos. Además, se inyecta `RequestIDMiddleware` para generar el encabezado `X-Request-ID` en cada respuesta.
+
 ## Autenticación
 
 - Credenciales diferenciadas por rol:


### PR DESCRIPTION
## Resumen
- Configuración de logging centralizada para el servicio web
- Middleware RequestID para propagar X-Request-ID
- Documentación de logging en el servicio web

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9cbd3d94883308443a2c1241ec3e5