### PR TITLE
Habilitar usuarios no root y limitar recursos de servicios

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -22,6 +22,10 @@ RUN python -m pip install --upgrade pip && pip install -r requirements.txt
 # Copiamos el código de la app
 COPY app /app/app
 
+# Crear usuario no root para ejecutar la API y aplicar principio de mínimos privilegios
+RUN useradd -m api && chown -R api:api /app
+USER api
+
 EXPOSE 8000
 
 # Arranque de la API

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -48,6 +48,11 @@ services:
       interval: 10s
       timeout: 5s
       retries: 12
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: "512M"
     networks:
       - lasfocas_net
 
@@ -83,6 +88,11 @@ services:
       interval: 10s
       timeout: 5s
       retries: 12
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: "1G"
     networks:
       - lasfocas_net
 
@@ -102,6 +112,11 @@ services:
       interval: 10s
       timeout: 5s
       retries: 12
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: "256M"
     networks:
       - lasfocas_net
 

--- a/deploy/docker/bot.Dockerfile
+++ b/deploy/docker/bot.Dockerfile
@@ -23,7 +23,8 @@ COPY bot_telegram /app/bot_telegram
 COPY modules /app/modules
 COPY core /app/core
 
-# Usuario no root opcional (hardening)
-# RUN useradd -m bot && chown -R bot:bot /app && USER bot
+# Usuario no root para ejecutar el bot y reducir riesgos de privilegios
+RUN useradd -m bot && chown -R bot:bot /app
+USER bot
 
 CMD ["python", "-m", "bot_telegram.app"]

--- a/docs/infra.md
+++ b/docs/infra.md
@@ -21,6 +21,16 @@
 - `./db/init.sql` se monta de forma de solo lectura para inicializar la base.
 - `ollama_data`: guarda los modelos descargados en `/root/.ollama`.
 
+## Recursos
+
+- `api`: límite de `1` CPU y `512MB` de RAM para evitar que una carga intensa afecte al resto de servicios.
+- `bot`: límite de `0.5` CPU y `256MB` de RAM, suficiente para manejar mensajes sin consumir recursos excesivos.
+- `nlp_intent`: límite de `1` CPU y `1GB` de RAM debido al procesamiento de lenguaje natural.
+
+## Seguridad
+
+- `api` y `bot` se ejecutan con un usuario no root dentro de sus contenedores, aplicando el principio de mínimos privilegios.
+
 ## Variables de entorno
 
 ### Base de datos


### PR DESCRIPTION
## Resumen
- Ejecutar contenedores `api` y `bot` con usuarios sin privilegios de root.
- Definir límites de CPU y memoria para `api`, `bot` y `nlp_intent` en `docker compose`.
- Documentar recursos asignados y refuerzo de seguridad en la infraestructura.

## Pruebas
- ❌ `docker compose -f deploy/compose.yml config` (docker no disponible en el entorno)


------
https://chatgpt.com/codex/tasks/task_e_68a9cca8dfdc8330a698a2ddd6092e15