### PR TITLE
[infra] Migrar credenciales a Docker secrets

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -7,15 +7,18 @@ POSTGRES_HOST=postgres
 POSTGRES_PORT=5432
 POSTGRES_DB=lasfocas
 POSTGRES_USER=lasfocas
-POSTGRES_PASSWORD=superseguro
+POSTGRES_PASSWORD=
+# Se carga desde /run/secrets/postgres_password cuando está disponible
 
 # Bot de Telegram
 TELEGRAM_BOT_TOKEN=
+# Se carga desde /run/secrets/telegram_bot_token cuando está disponible
 TELEGRAM_ALLOWED_IDS=11111111,22222222
 
 # NLP / LLM
 LLM_PROVIDER=auto
 OPENAI_API_KEY=
+# Se carga desde /run/secrets/openai_api_key cuando está disponible
 # URL base para el servicio Ollama interno
 OLLAMA_URL=http://ollama:11434
 INTENT_THRESHOLD=0.7
@@ -47,7 +50,11 @@ WEB_LECTOR_PASSWORD=lectura
 # Integraciones
 NOTION_TOKEN=
 SMTP_HOST=
+# Se carga desde /run/secrets/smtp_host cuando está disponible
 SMTP_PORT=587
 SMTP_USER=
+# Se carga desde /run/secrets/smtp_user cuando está disponible
 SMTP_PASSWORD=
+# Se carga desde /run/secrets/smtp_password cuando está disponible
 SMTP_FROM=
+# Se carga desde /run/secrets/smtp_from cuando está disponible

--- a/README.md
+++ b/README.md
@@ -132,15 +132,18 @@ POSTGRES_HOST=postgres
 POSTGRES_PORT=5432
 POSTGRES_DB=lasfocas
 POSTGRES_USER=lasfocas
-POSTGRES_PASSWORD=superseguro
+POSTGRES_PASSWORD=
+# Se carga desde /run/secrets/postgres_password cuando está disponible
 
 # Bot de Telegram
 TELEGRAM_BOT_TOKEN=
+# Se carga desde /run/secrets/telegram_bot_token cuando está disponible
 TELEGRAM_ALLOWED_IDS=11111111,22222222
 
 # NLP / LLM
 LLM_PROVIDER=auto
 OPENAI_API_KEY=
+# Se carga desde /run/secrets/openai_api_key cuando está disponible
 # URL base para el servicio Ollama interno
 OLLAMA_URL=http://ollama:11434
 INTENT_THRESHOLD=0.7
@@ -162,6 +165,18 @@ WORK_HOURS=false
 # Rate limiting
 API_RATE_LIMIT=60/minute
 NLP_RATE_LIMIT=60/minute
+
+# Integraciones
+NOTION_TOKEN=
+SMTP_HOST=
+# Se carga desde /run/secrets/smtp_host cuando está disponible
+SMTP_PORT=587
+SMTP_USER=
+# Se carga desde /run/secrets/smtp_user cuando está disponible
+SMTP_PASSWORD=
+# Se carga desde /run/secrets/smtp_password cuando está disponible
+SMTP_FROM=
+# Se carga desde /run/secrets/smtp_from cuando está disponible
 ```
 La variable `WORK_HOURS` permite ajustar el cálculo del TTR al horario laboral; en `false` se usa el total de horas calendario.
 Las solicitudes a la API deben incluir el encabezado `X-API-Key`; el límite se calcula por clave (o por IP si falta).

--- a/api/app/db.py
+++ b/api/app/db.py
@@ -4,6 +4,7 @@
 from os import getenv
 import logging
 from sqlalchemy import create_engine, text
+from core import get_secret
 
 
 logger = logging.getLogger(__name__)
@@ -12,7 +13,7 @@ DB_HOST = getenv("POSTGRES_HOST", "postgres")
 DB_PORT = getenv("POSTGRES_PORT", "5432")
 DB_NAME = getenv("POSTGRES_DB", "lasfocas")
 DB_USER = getenv("POSTGRES_USER", "lasfocas")
-DB_PASS = getenv("POSTGRES_PASSWORD", "cambiar-este-password")
+DB_PASS = get_secret("POSTGRES_PASSWORD", "cambiar-este-password")
 
 DSN = f"postgresql+psycopg://{DB_USER}:{DB_PASS}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
 

--- a/bot_telegram/app.py
+++ b/bot_telegram/app.py
@@ -4,7 +4,6 @@
 
 import asyncio
 import logging
-import os
 
 from aiogram import Bot, Dispatcher
 from aiogram.client.default import DefaultBotProperties
@@ -19,11 +18,12 @@ from bot_telegram.handlers.intent import router as intent_router
 from bot_telegram.handlers.menu import router as menu_router
 from bot_telegram.middlewares.request_id import RequestContextMiddleware
 from core.logging import configure_logging
+from core import get_secret
 
 configure_logging("bot")
 logger = logging.getLogger("bot")
 
-TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
+TOKEN = get_secret("TELEGRAM_BOT_TOKEN")
 
 
 async def main():

--- a/bot_telegram/handlers/intent.py
+++ b/bot_telegram/handlers/intent.py
@@ -1,6 +1,6 @@
 # Nombre de archivo: intent.py
 # Ubicación de archivo: bot_telegram/handlers/intent.py
-# Descripción: Manejo de mensajes de texto con clasificación de intención y persistencia
+# Descripción: Manejo de mensajes con clasificación de intención y persistencia
 
 from __future__ import annotations
 
@@ -21,6 +21,7 @@ from bot_telegram.flows.sla import start_sla_flow
 from bot_telegram.ui.menu import build_main_menu
 from core.repositories.conversations import insert_conversation
 from core.repositories.messages import insert_message
+from core import get_secret
 
 router = Router()
 logger = logging.getLogger(__name__)
@@ -43,7 +44,7 @@ def _get_conn() -> psycopg.Connection:
         host=os.getenv("POSTGRES_HOST", "localhost"),
         dbname=os.getenv("POSTGRES_DB"),
         user=os.getenv("POSTGRES_USER"),
-        password=os.getenv("POSTGRES_PASSWORD"),
+        password=get_secret("POSTGRES_PASSWORD"),
     )
 
 
@@ -103,5 +104,3 @@ async def classify_message(msg: Message, state: FSMContext):
             )
     else:
         await msg.answer(summary)
-
-

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -2,3 +2,8 @@
 # Ubicación de archivo: core/__init__.py
 # Descripción: Inicializa el paquete de utilidades centrales
 
+"""Punto de entrada para utilidades compartidas del proyecto."""
+
+from .secrets import get_secret
+
+__all__ = ["get_secret"]

--- a/core/secrets.py
+++ b/core/secrets.py
@@ -1,0 +1,41 @@
+# Nombre de archivo: secrets.py
+# Ubicación de archivo: core/secrets.py
+# Descripción: Utilidades para cargar secretos desde variables de entorno o Docker secrets
+
+"""Funciones para leer secretos de variables de entorno o archivos en `/run/secrets`.
+
+Estas utilidades permiten que los servicios utilicen Docker Secrets sin cambiar
+las variables de entorno existentes. Si la variable no está definida, se busca
+un archivo con el mismo nombre (en minúsculas) dentro de `/run/secrets`.
+"""
+
+from pathlib import Path
+from typing import Optional
+import os
+
+
+def get_secret(name: str, default: Optional[str] = None) -> Optional[str]:
+    """Obtiene el secreto `name` desde variables de entorno o `/run/secrets`.
+
+    Parameters
+    ----------
+    name:
+        Nombre de la variable de entorno a buscar.
+    default:
+        Valor a retornar si no se encuentra el secreto.
+
+    Returns
+    -------
+    Optional[str]
+        Valor del secreto o `default` si no está disponible.
+    """
+
+    value = os.getenv(name)
+    if value:
+        return value
+
+    secret_file = Path("/run/secrets") / name.lower()
+    try:
+        return secret_file.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        return default

--- a/db/migrations/env.py
+++ b/db/migrations/env.py
@@ -6,6 +6,7 @@ from logging.config import fileConfig
 import os
 from sqlalchemy import engine_from_config, pool
 from alembic import context
+from core import get_secret
 
 # Objeto de configuración de Alembic
 config = context.config
@@ -15,7 +16,7 @@ if config.config_file_name is not None:
 
 # Construir la URL de conexión desde variables de entorno
 _db_user = os.getenv("POSTGRES_USER", "lasfocas")
-_db_password = os.getenv("POSTGRES_PASSWORD", "lasfocas")
+_db_password = get_secret("POSTGRES_PASSWORD", "lasfocas")
 _db_host = os.getenv("POSTGRES_HOST", "localhost")
 _db_port = os.getenv("POSTGRES_PORT", "5432")
 _db_name = os.getenv("POSTGRES_DB", "lasfocas")

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -13,12 +13,14 @@ services:
     environment:
       POSTGRES_DB: ${POSTGRES_DB}
       POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
     expose:
       - "5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./db/init.sql:/docker-entrypoint-initdb.d/00-init.sql:ro
+    secrets:
+      - postgres_password
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB} -h localhost"]
       interval: 5s
@@ -55,6 +57,12 @@ services:
           memory: "512M"
     networks:
       - lasfocas_net
+    secrets:
+      - postgres_password
+      - smtp_host
+      - smtp_user
+      - smtp_password
+      - smtp_from
 
   web:
     build:
@@ -83,6 +91,8 @@ services:
     expose:
       - "8100"
     restart: unless-stopped
+    secrets:
+      - openai_api_key
     healthcheck:
       test: ["CMD-SHELL", "sh /app/app/healthcheck.sh"]
       interval: 10s
@@ -107,6 +117,9 @@ services:
     restart: unless-stopped
     volumes:
       - bot_data:/app/data
+    secrets:
+      - telegram_bot_token
+      - postgres_password
     healthcheck:
       test: ["CMD-SHELL", "sh /app/bot_telegram/healthcheck.sh"]
       interval: 10s
@@ -156,6 +169,22 @@ volumes:
   postgres_data:
   bot_data:
   ollama_data:
+
+secrets:
+  postgres_password:
+    file: ./secrets/postgres_password
+  telegram_bot_token:
+    file: ./secrets/telegram_bot_token
+  openai_api_key:
+    file: ./secrets/openai_api_key
+  smtp_host:
+    file: ./secrets/smtp_host
+  smtp_user:
+    file: ./secrets/smtp_user
+  smtp_password:
+    file: ./secrets/smtp_password
+  smtp_from:
+    file: ./secrets/smtp_from
 
 networks:
   lasfocas_net:

--- a/deploy/env.sample
+++ b/deploy/env.sample
@@ -7,15 +7,18 @@ POSTGRES_HOST=postgres
 POSTGRES_PORT=5432
 POSTGRES_DB=lasfocas
 POSTGRES_USER=lasfocas
-POSTGRES_PASSWORD=superseguro
+POSTGRES_PASSWORD=
+# Se carga desde /run/secrets/postgres_password cuando está disponible
 
 # Bot de Telegram
 TELEGRAM_BOT_TOKEN=
+# Se carga desde /run/secrets/telegram_bot_token cuando está disponible
 TELEGRAM_ALLOWED_IDS=11111111,22222222
 
 # NLP / LLM
 LLM_PROVIDER=auto
 OPENAI_API_KEY=
+# Se carga desde /run/secrets/openai_api_key cuando está disponible
 # URL base para el servicio Ollama interno
 OLLAMA_URL=http://ollama:11434
 INTENT_THRESHOLD=0.7

--- a/docs/bot.md
+++ b/docs/bot.md
@@ -3,7 +3,7 @@
 # Descripción: Guía rápida de uso del bot de Telegram
 
 ## Variables requeridas (.env)
-- TELEGRAM_BOT_TOKEN=...
+- TELEGRAM_BOT_TOKEN=... (o Docker Secret `telegram_bot_token`)
 - TELEGRAM_ALLOWED_IDS=11111111,22222222
 
 ## Arranque con Docker

--- a/docs/db.md
+++ b/docs/db.md
@@ -10,6 +10,7 @@ La cadena DSN se construye a partir de variables de entorno:
 - `POSTGRES_DB`: nombre de la base de datos.
 - `POSTGRES_USER`: usuario para la conexión.
 - `POSTGRES_PASSWORD`: contraseña del usuario.
+  Se lee desde la variable de entorno o el archivo `/run/secrets/postgres_password`.
 
 En `deploy/compose.yml` la base de datos solo se expone a otros contenedores mediante `expose: 5432`, evitando publicar el puerto en el host.
 

--- a/docs/infra.md
+++ b/docs/infra.md
@@ -33,6 +33,8 @@
 
 ## Variables de entorno
 
+Las credenciales sensibles (`POSTGRES_PASSWORD`, `TELEGRAM_BOT_TOKEN`, `OPENAI_API_KEY` y `SMTP_*`) se obtienen desde archivos en `/run/secrets/` cuando se utilizan Docker Secrets.
+
 ### Base de datos
 - `POSTGRES_HOST`: host del contenedor de PostgreSQL.
 - `POSTGRES_PORT`: puerto interno donde escucha PostgreSQL.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -18,7 +18,8 @@ cliente.create_page({"parent": {"database_id": "db"}, "properties": {}})
 
 Cliente para el envío de correos electrónicos.
 Utiliza las variables `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD`
-y `SMTP_FROM` para autenticarse y definir el remitente.
+y `SMTP_FROM` para autenticarse y definir el remitente. Estas credenciales
+pueden suministrarse mediante Docker Secrets montados en `/run/secrets/`.
 
 ```python
 from integrations.email import EmailClient

--- a/docs/security.md
+++ b/docs/security.md
@@ -4,8 +4,14 @@
 
 ## Secrets
 
-- Las credenciales se gestionan mediante variables de entorno definidas en `.env` y no se versionan.
-- Para producción se recomienda migrar a **Docker Secrets** o gestores como Vault.
+- Las credenciales se gestionan mediante **Docker Secrets** montados en `/run/secrets/*`.
+- Secretos usados: `postgres_password`, `telegram_bot_token`, `openai_api_key`, `smtp_host`, `smtp_user`, `smtp_password` y `smtp_from`.
+- Para crear un secreto, generar el archivo en `deploy/secrets/<nombre>`:
+  ```bash
+  echo "valor" > deploy/secrets/postgres_password
+  ```
+  Luego reiniciar los servicios con `docker compose -f deploy/compose.yml up -d`.
+- Para rotar un secreto, actualizar el archivo correspondiente y volver a desplegar el servicio que lo consume.
 - No se deben exponer tokens ni contraseñas en logs ni commits.
 
 ## Rate limiting

--- a/integrations/email.py
+++ b/integrations/email.py
@@ -6,6 +6,7 @@ import logging
 import os
 import smtplib
 from email.message import EmailMessage
+from core import get_secret
 
 logger = logging.getLogger(__name__)
 
@@ -22,11 +23,11 @@ class EmailClient:
         sender: str | None = None,
         use_tls: bool = True,
     ) -> None:
-        self.host = host or os.getenv("SMTP_HOST", "")
+        self.host = host or get_secret("SMTP_HOST") or ""
         self.port = port or int(os.getenv("SMTP_PORT", "587"))
-        self.user = user or os.getenv("SMTP_USER", "")
-        self.password = password or os.getenv("SMTP_PASSWORD", "")
-        self.sender = sender or os.getenv("SMTP_FROM", self.user)
+        self.user = user or get_secret("SMTP_USER") or ""
+        self.password = password or get_secret("SMTP_PASSWORD") or ""
+        self.sender = sender or get_secret("SMTP_FROM") or self.user
         self.use_tls = use_tls
 
     def send_mail(self, to: str, subject: str, body: str) -> None:

--- a/nlp_intent/app/config.py
+++ b/nlp_intent/app/config.py
@@ -6,12 +6,13 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from core import get_secret
 
 
 @dataclass
 class Settings:
     llm_provider: str = os.getenv("LLM_PROVIDER", "auto")
-    openai_api_key: str | None = os.getenv("OPENAI_API_KEY")
+    openai_api_key: str | None = get_secret("OPENAI_API_KEY")
     ollama_url: str = os.getenv("OLLAMA_URL", "http://ollama:11434")
     intent_threshold: float = float(os.getenv("INTENT_THRESHOLD", "0.7"))
     lang: str = os.getenv("LANG", "es")


### PR DESCRIPTION
## Resumen
- Gestionar credenciales sensibles mediante Docker Secrets montados en `/run/secrets`
- Incorporar utilitario `get_secret` para leer secretos desde archivos o entorno
- Documentar creación y rotación de secretos en `docs/security.md`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9ccff8f0883309ee2723e86169d77