### PR TITLE
Validación de confianza al consultar nlp_intent

### DIFF
--- a/docs/bot.md
+++ b/docs/bot.md
@@ -6,6 +6,7 @@
 
 ## Variables requeridas (.env)
 - TELEGRAM_ALLOWED_IDS=11111111,22222222
+- INTENT_THRESHOLD=0.7  # Umbral mínimo de confianza para aceptar una intención
 
 ## Arranque con Docker
 
@@ -40,8 +41,8 @@ Los intentos de acceso de usuarios no incluidos en `TELEGRAM_ALLOWED_IDS` genera
 
 ## Clasificación de intención
 
-Cada mensaje de texto se envía al microservicio `nlp_intent` para determinar si es una **Consulta**, una **Acción** u **Otros**.
-El bot responde con un resumen de la intención detectada. Si la confianza es baja, solicita una aclaración al usuario.
+Cada mensaje de texto se envía mediante `httpx` al microservicio `nlp_intent` para determinar si es una **Consulta**, una **Acción** u **Otros**.
+El bot responde con un resumen de la intención detectada. Si la confianza devuelta es menor que `INTENT_THRESHOLD` (0.7 por defecto), solicita una aclaración al usuario antes de continuar.
 
 ## Menú principal
 

--- a/docs/nlp/intent.md
+++ b/docs/nlp/intent.md
@@ -26,6 +26,13 @@ Servicio FastAPI para clasificar mensajes de usuario en una de tres intenciones:
 }
 ```
 
+## Integración con el bot de Telegram
+
+El bot de Telegram consume `POST /v1/intent:classify` mediante `httpx` para
+analizar los mensajes de los usuarios. Si la confianza devuelta es menor que
+`INTENT_THRESHOLD` (0.7 por defecto), responde pidiendo una aclaración para
+comprender mejor la intención.
+
 ## Orden de proveedores
 
 1. Heurística local (rápida).


### PR DESCRIPTION
## Resumen
- Manejo de errores al consumir `nlp_intent` desde el bot de Telegram utilizando `httpx`
- Solicitud de aclaración al usuario cuando la confianza es menor que `INTENT_THRESHOLD`
- Documentación actualizada del flujo de clasificación y variables de entorno

## Pruebas
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9d47199808330913fccac177e59d2