### PR TITLE
[bot] Mejoras de validación y limpieza en repetitividad

### DIFF
--- a/docs/informes/repetitividad.md
+++ b/docs/informes/repetitividad.md
@@ -5,12 +5,14 @@
 ## Insumos requeridos
 - Excel "Casos" en formato `.xlsx`.
 - Tamaño máximo permitido: 10MB.
+- El nombre del archivo no debe contener rutas ni caracteres especiales.
 - Columnas mínimas: `CLIENTE`, `SERVICIO`, `FECHA` y opcional `ID_SERVICIO`.
 - Los datos del cliente **BANCO MACRO SA** nunca se filtran automáticamente.
 
 ## Validaciones
 - `CLIENTE` y `SERVICIO` deben ser texto de hasta 100 caracteres.
 - `FECHA` debe contener valores de fecha válidos.
+- El período debe ingresarse en formato `mm/aaaa` y estar dentro del rango desde 2000.
 
 ## Cálculo
 - Se normalizan las columnas y se genera `PERIODO = YYYY-MM`.
@@ -27,6 +29,9 @@
 
 ## Paths de salida
 - Archivos generados en `/app/data/reports/` dentro del contenedor del bot.
+
+## Limpieza de archivos
+- Los archivos subidos y los informes generados se eliminan automáticamente luego de ser enviados al usuario.
 
 ## Variables de entorno
 - `REP_TEMPLATE_PATH=/app/templates/repetitividad.docx` ruta de la plantilla.

--- a/tests/test_repetitividad_flow_validations.py
+++ b/tests/test_repetitividad_flow_validations.py
@@ -3,8 +3,13 @@
 # Descripción: Pruebas de validaciones del flujo de repetitividad
 
 from types import SimpleNamespace
+from pathlib import Path
 
-from bot_telegram.flows.repetitividad import validate_document
+from bot_telegram.flows.repetitividad import (
+    cleanup_files,
+    validate_document,
+    validate_period,
+)
 
 
 def test_validate_document_extension() -> None:
@@ -29,3 +34,44 @@ def test_validate_document_ok() -> None:
     valido, error = validate_document(doc)
     assert valido
     assert error == ""
+
+
+def test_validate_document_rejects_path(tmp_path: Path) -> None:
+    """Rechaza nombres de archivo con rutas embebidas."""
+    doc = SimpleNamespace(file_name="../datos.xlsx", file_size=1024)
+    valido, error = validate_document(doc)
+    assert not valido
+    assert "nombre del archivo" in error
+
+
+def test_validate_period_format() -> None:
+    """Valida que el formato sea mm/aaaa."""
+    valido, error, _, _ = validate_period("2024-07")
+    assert not valido
+    assert "Formato" in error
+
+
+def test_validate_period_range() -> None:
+    """Rechaza períodos fuera de rango."""
+    valido, error, _, _ = validate_period("13/1999")
+    assert not valido
+    assert "rango" in error
+
+
+def test_validate_period_ok() -> None:
+    """Acepta períodos válidos."""
+    valido, error, mes, anio = validate_period("07/2024")
+    assert valido
+    assert error == ""
+    assert (mes, anio) == (7, 2024)
+
+
+def test_cleanup_files(tmp_path: Path) -> None:
+    """Elimina archivos temporales sin errores."""
+    f1 = tmp_path / "a.txt"
+    f2 = tmp_path / "b.txt"
+    for f in (f1, f2):
+        f.write_text("data")
+        assert f.exists()
+    cleanup_files(str(f1), str(f2))
+    assert not f1.exists() and not f2.exists()


### PR DESCRIPTION
## Resumen
- validar nombres y períodos en flujo de repetitividad
- limpiar archivos temporales luego de generar informes
- documentar nuevas validaciones y limpieza

## Pruebas
- `PYTHONPATH=. pytest tests/test_repetitividad_flow_validations.py`

------
https://chatgpt.com/codex/tasks/task_e_68a9d74abd8c8330a97549a2b6115bb6