### PR TITLE
[infra] Añadir worker y redis opcional

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -43,12 +43,17 @@ NLP_RATE_LIMIT=60/minute
 
 # Web Panel
 WEB_ADMIN_USERNAME=admin
+# Se carga desde /run/secrets/web_admin_username cuando está disponible
 WEB_ADMIN_PASSWORD=changeme
+# Se carga desde /run/secrets/web_admin_password cuando está disponible
 WEB_LECTOR_USERNAME=lector
+# Se carga desde /run/secrets/web_lector_username cuando está disponible
 WEB_LECTOR_PASSWORD=lectura
+# Se carga desde /run/secrets/web_lector_password cuando está disponible
 
 # Integraciones
 NOTION_TOKEN=
+# Se carga desde /run/secrets/notion_token cuando está disponible
 SMTP_HOST=
 # Se carga desde /run/secrets/smtp_host cuando está disponible
 SMTP_PORT=587

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -26,6 +26,11 @@ services:
       interval: 5s
       timeout: 5s
       retries: 20
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: "512M"
     networks:
       - lasfocas_net
 
@@ -63,6 +68,7 @@ services:
       - smtp_user
       - smtp_password
       - smtp_from
+      - notion_token
 
   web:
     build:
@@ -79,8 +85,19 @@ services:
       interval: 10s
       timeout: 5s
       retries: 12
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: "256M"
     networks:
       - lasfocas_net
+    secrets:
+      - web_admin_username
+      - web_admin_password
+      - web_lector_username
+      - web_lector_password
+      - notion_token
 
   nlp_intent:
     build:
@@ -133,6 +150,43 @@ services:
     networks:
       - lasfocas_net
 
+  worker:
+    build:
+      context: ..
+      dockerfile: deploy/docker/worker.Dockerfile
+    env_file:
+      - ../.env
+    depends_on:
+      - postgres
+      - redis
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: "256M"
+    networks:
+      - lasfocas_net
+    secrets:
+      - postgres_password
+      - notion_token
+    profiles: ["worker"]
+
+  redis:
+    image: redis:7-alpine
+    container_name: lasfocas-redis
+    restart: unless-stopped
+    expose:
+      - "6379"
+    deploy:
+      resources:
+        limits:
+          cpus: "0.25"
+          memory: "128M"
+    networks:
+      - lasfocas_net
+    profiles: ["worker"]
+
   ollama:
     image: ollama/ollama:0.11.6
     container_name: lasfocas-ollama
@@ -146,6 +200,11 @@ services:
       retries: 12
     volumes:
       - ollama_data:/root/.ollama
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: "2G"
     networks:
       - lasfocas_net
 
@@ -185,8 +244,17 @@ secrets:
     file: ./secrets/smtp_password
   smtp_from:
     file: ./secrets/smtp_from
+  web_admin_username:
+    file: ./secrets/web_admin_username
+  web_admin_password:
+    file: ./secrets/web_admin_password
+  web_lector_username:
+    file: ./secrets/web_lector_username
+  web_lector_password:
+    file: ./secrets/web_lector_password
+  notion_token:
+    file: ./secrets/notion_token
 
 networks:
   lasfocas_net:
     driver: bridge
-

--- a/deploy/docker/worker.Dockerfile
+++ b/deploy/docker/worker.Dockerfile
@@ -1,0 +1,18 @@
+# Nombre de archivo: worker.Dockerfile
+# Ubicación de archivo: deploy/docker/worker.Dockerfile
+# Descripción: Imagen para el servicio de tareas en segundo plano
+
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY ../../requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r /app/requirements.txt
+
+COPY ../../modules /app/modules
+COPY ../../core /app/core
+
+RUN useradd -m worker && chown -R worker:worker /app
+USER worker
+
+CMD ["python", "-m", "modules.worker"]

--- a/deploy/env.sample
+++ b/deploy/env.sample
@@ -43,6 +43,14 @@ NLP_RATE_LIMIT=60/minute
 
 # Web Panel
 WEB_ADMIN_USERNAME=admin
+# Se carga desde /run/secrets/web_admin_username cuando está disponible
 WEB_ADMIN_PASSWORD=changeme
+# Se carga desde /run/secrets/web_admin_password cuando está disponible
 WEB_LECTOR_USERNAME=lector
+# Se carga desde /run/secrets/web_lector_username cuando está disponible
 WEB_LECTOR_PASSWORD=lectura
+# Se carga desde /run/secrets/web_lector_password cuando está disponible
+
+# Integraciones
+NOTION_TOKEN=
+# Se carga desde /run/secrets/notion_token cuando está disponible

--- a/docs/infra.md
+++ b/docs/infra.md
@@ -11,6 +11,7 @@
 - `postgres` expone `5432` solo a la red interna mediante `expose`.
 - `api` publica `8000:8000` para acceso HTTP desde el host.
 - `nlp_intent` expone `8100` únicamente a la red interna.
+- `redis` expone `6379` solo a la red interna y se activa con el perfil `worker`.
 - `ollama` expone `11434` solo a la red interna.
 - `pgadmin` (perfil opcional) publica `5050:80` para administración de PostgreSQL.
 
@@ -23,17 +24,22 @@
 
 ## Recursos
 
+- `postgres`: límite de `0.5` CPU y `512MB` de RAM para contener el uso de la base.
 - `api`: límite de `1` CPU y `512MB` de RAM para evitar que una carga intensa afecte al resto de servicios.
+- `web`: límite de `0.5` CPU y `256MB` de RAM para servir contenido estático con bajo consumo.
 - `bot`: límite de `0.5` CPU y `256MB` de RAM, suficiente para manejar mensajes sin consumir recursos excesivos.
+- `worker`: límite de `0.5` CPU y `256MB` de RAM destinado a tareas en segundo plano.
+- `redis`: límite de `0.25` CPU y `128MB` de RAM; solo se inicia con el perfil `worker`.
 - `nlp_intent`: límite de `1` CPU y `1GB` de RAM debido al procesamiento de lenguaje natural.
+- `ollama`: límite de `1` CPU y `2GB` de RAM para el servicio de modelos LLM.
 
 ## Seguridad
 
-- `api` y `bot` se ejecutan con un usuario no root dentro de sus contenedores, aplicando el principio de mínimos privilegios.
+- `api`, `bot`, `web` y `worker` se ejecutan con un usuario no root dentro de sus contenedores, aplicando el principio de mínimos privilegios.
 
 ## Variables de entorno
 
-Las credenciales sensibles (`POSTGRES_PASSWORD`, `TELEGRAM_BOT_TOKEN`, `OPENAI_API_KEY` y `SMTP_*`) se obtienen desde archivos en `/run/secrets/` cuando se utilizan Docker Secrets.
+Las credenciales sensibles (`POSTGRES_PASSWORD`, `TELEGRAM_BOT_TOKEN`, `OPENAI_API_KEY`, `SMTP_*`, `WEB_ADMIN_*`, `WEB_LECTOR_*` y `NOTION_TOKEN`) se obtienen desde archivos en `/run/secrets/` cuando se utilizan Docker Secrets.
 
 ### Base de datos
 - `POSTGRES_HOST`: host del contenedor de PostgreSQL.

--- a/docs/security.md
+++ b/docs/security.md
@@ -5,7 +5,7 @@
 ## Secrets
 
 - Las credenciales se gestionan mediante **Docker Secrets** montados en `/run/secrets/*`.
-- Secretos usados: `postgres_password`, `telegram_bot_token`, `openai_api_key`, `smtp_host`, `smtp_user`, `smtp_password` y `smtp_from`.
+- Secretos usados: `postgres_password`, `telegram_bot_token`, `openai_api_key`, `smtp_host`, `smtp_user`, `smtp_password`, `smtp_from`, `web_admin_username`, `web_admin_password`, `web_lector_username`, `web_lector_password` y `notion_token`.
 - Para crear un secreto, generar el archivo en `deploy/secrets/<nombre>`:
   ```bash
   echo "valor" > deploy/secrets/postgres_password

--- a/modules/worker.py
+++ b/modules/worker.py
@@ -1,0 +1,26 @@
+# Nombre de archivo: worker.py
+# Ubicación de archivo: modules/worker.py
+# Descripción: Proceso base para ejecutar tareas en segundo plano
+"""Inicio simple del servicio worker."""
+
+from time import sleep
+import logging
+
+from core.logging import configure_logging
+
+configure_logging("worker")
+logger = logging.getLogger("worker")
+
+
+def main() -> None:
+    """Bucle principal del worker."""
+    logger.info("action=worker_iniciado")
+    try:
+        while True:
+            sleep(60)
+    except KeyboardInterrupt:
+        logger.info("action=worker_detener")
+
+
+if __name__ == "__main__":
+    main()

--- a/web/main.py
+++ b/web/main.py
@@ -6,8 +6,8 @@
 
 import base64
 import logging
-import os
 from pathlib import Path
+from core import get_secret
 
 from fastapi import Depends, FastAPI, HTTPException, Request, Response, status
 from fastapi.responses import HTMLResponse
@@ -26,10 +26,10 @@ class BasicAuthMiddleware(BaseHTTPMiddleware):
 
     def __init__(self, app: FastAPI) -> None:
         super().__init__(app)
-        self.admin_user = os.getenv("WEB_ADMIN_USERNAME") or os.getenv("WEB_USERNAME", "")
-        self.admin_pass = os.getenv("WEB_ADMIN_PASSWORD") or os.getenv("WEB_PASSWORD", "")
-        self.reader_user = os.getenv("WEB_LECTOR_USERNAME", "")
-        self.reader_pass = os.getenv("WEB_LECTOR_PASSWORD", "")
+        self.admin_user = get_secret("WEB_ADMIN_USERNAME") or get_secret("WEB_USERNAME", "")
+        self.admin_pass = get_secret("WEB_ADMIN_PASSWORD") or get_secret("WEB_PASSWORD", "")
+        self.reader_user = get_secret("WEB_LECTOR_USERNAME", "")
+        self.reader_pass = get_secret("WEB_LECTOR_PASSWORD", "")
         if not self.admin_user or not self.admin_pass:
             logger.warning(
                 "action=init_basic_auth falta_env=credenciales_admin",


### PR DESCRIPTION
## Resumen
- Agregado servicio worker con límites de recursos
- Redis opcional y migración de credenciales a Docker Secrets
- Documentación de infraestructura y seguridad actualizada

## Pruebas
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9d9657ad483309320e7bf86ed86c6