### PR TITLE
[metrics] Añadir métricas y cobertura

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,13 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-      - name: Ejecutar pytest
-        run: pytest
+      - name: Ejecutar pytest con cobertura
+        run: |
+          pytest --cov=. --cov-report=xml
+      - name: Subir reporte de cobertura
+        uses: actions/upload-artifact@v4
+        with:
+          name: cobertura
+          path: coverage.xml
       - name: Ejecutar ruff
         run: ruff check .

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -1,9 +1,10 @@
 # Nombre de archivo: main.py
 # Ubicación de archivo: api/app/main.py
-# Descripción: Aplicación FastAPI principal con limitación de tasa
+# Descripción: Aplicación FastAPI principal con limitación de tasa y métricas
 
 from fastapi import FastAPI, Request
 import os
+import time
 from slowapi.middleware import SlowAPIMiddleware
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.util import get_remote_address
@@ -12,13 +13,16 @@ from slowapi.errors import RateLimitExceeded
 from app.routes.health import router as health_router
 from core.logging import configure_logging
 from core.middlewares import RequestIDMiddleware
+from core.metrics import Metrics
 
 configure_logging("api")
+metrics = Metrics()
 
 
 def get_api_key_or_ip(request: Request) -> str:
     """Obtiene la API key del encabezado o la IP si no está presente."""
     return request.headers.get("X-API-Key") or get_remote_address(request)
+
 
 def create_app() -> FastAPI:
     """Crea la instancia principal de FastAPI y aplica rate limiting."""
@@ -27,10 +31,24 @@ def create_app() -> FastAPI:
 
     app = FastAPI(title="LAS-FOCAS API", version="0.1.0")
     app.state.limiter = limiter
+    app.state.metrics = metrics
     app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
     app.add_middleware(SlowAPIMiddleware)
     app.add_middleware(RequestIDMiddleware)
     app.include_router(health_router, tags=["health"])
+
+    @app.middleware("http")
+    async def collect_metrics(request: Request, call_next):
+        inicio = time.perf_counter()
+        response = await call_next(request)
+        app.state.metrics.record(time.perf_counter() - inicio)
+        return response
+
+    @app.get("/metrics")
+    async def metrics_endpoint() -> dict[str, float]:
+        """Devuelve métricas básicas del servicio."""
+        return app.state.metrics.snapshot()
+
     return app
 
 

--- a/core/metrics.py
+++ b/core/metrics.py
@@ -1,0 +1,35 @@
+# Nombre de archivo: metrics.py
+# Ubicación de archivo: core/metrics.py
+# Descripción: Acumulador simple de métricas de latencia y conteo
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Metrics:
+    """Acumulador básico de métricas del servicio."""
+
+    total_requests: int = 0
+    total_latency: float = 0.0
+
+    def record(self, latency: float) -> None:
+        """Registra una nueva solicitud y su latencia."""
+        self.total_requests += 1
+        self.total_latency += latency
+
+    def snapshot(self) -> dict[str, float]:
+        """Devuelve un resumen con promedio de latencia en ms."""
+        promedio = (
+            self.total_latency / self.total_requests if self.total_requests else 0.0
+        )
+        return {
+            "total_requests": self.total_requests,
+            "average_latency_ms": promedio * 1000,
+        }
+
+    def reset(self) -> None:
+        """Reinicia los contadores."""
+        self.total_requests = 0
+        self.total_latency = 0.0

--- a/docs/api.md
+++ b/docs/api.md
@@ -43,6 +43,22 @@
   El campo `detail` incluye el mensaje original de la excepción capturada.
 
 
+
+
+## Métricas
+
+- **Ruta:** `GET /metrics`
+- **Descripción:** expone contadores básicos del servicio.
+- **Respuesta:**
+
+```json
+{
+  "total_requests": 0,
+  "average_latency_ms": 0.0
+}
+```
+
+
 ## Rate limiting
 
 - **Variable:** `API_RATE_LIMIT` (por defecto `60/minute`).

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -8,7 +8,8 @@ El proyecto ejecuta un flujo de **integración continua** mediante GitHub Action
 
 1. **Checkout** del repositorio.
 2. **Instalación de dependencias** definidas en `requirements.txt`.
-3. Ejecución de las **pruebas** con `pytest`.
-4. Análisis de estilo y calidad de código con **`ruff`**.
+3. Ejecución de las **pruebas** con `pytest` generando reporte de cobertura.
+4. **Carga** del archivo `coverage.xml` como artefacto de la ejecución.
+5. Análisis de estilo y calidad de código con **`ruff`**.
 
 La finalidad es garantizar que el código pase las pruebas automatizadas y cumpla las reglas de estilo antes de integrarse en la rama principal.

--- a/docs/web.md
+++ b/docs/web.md
@@ -27,6 +27,7 @@ El repositorio incluye un microservicio en `web/main.py` que utiliza **FastAPI**
 - `GET /health` responde con `{"status": "ok"}` para verificaciones de salud.
 - `GET /admin` accesible solo para usuarios con rol `admin`.
 - `GET /login` entrega un formulario de acceso aún en desarrollo.
+- `GET /metrics` expone métricas simples sin autenticación.
 
 Este servicio se construye con `web/Dockerfile` sobre la imagen `python:3.11-slim` y se despliega mediante `deploy/compose.yml` como servicio `web`, publicando el puerto `8080` al host.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@
 fastapi==0.110.1  # Framework web para APIs
 uvicorn[standard]==0.29.0  # Servidor ASGI para FastAPI
 pytest==8.3.2  # Marco de pruebas
+pytest-cov==5.0.0  # Plugin de cobertura para pytest
 httpx==0.27.0  # Cliente HTTP asíncrono
 sqlalchemy==2.0.32  # ORM para interactuar con la base de datos
 psycopg[binary]==3.1.19  # Driver PostgreSQL en formato binario

--- a/tests/test_api_metrics.py
+++ b/tests/test_api_metrics.py
@@ -1,0 +1,24 @@
+# Nombre de archivo: test_api_metrics.py
+# Ubicación de archivo: tests/test_api_metrics.py
+# Descripción: Prueba del endpoint /metrics de la API principal
+
+from pathlib import Path
+import sys
+
+from fastapi.testclient import TestClient
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+sys.path.append(str(Path(__file__).resolve().parents[1] / "api"))
+
+from app.main import create_app
+
+
+def test_metrics_endpoint_muestra_datos() -> None:
+    app = create_app()
+    client = TestClient(app)
+    client.get("/health")
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "total_requests" in data
+    assert "average_latency_ms" in data

--- a/tests/test_libreoffice_export.py
+++ b/tests/test_libreoffice_export.py
@@ -4,10 +4,14 @@
 
 from pathlib import Path
 import subprocess
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import pytest
 
 from modules.common.libreoffice_export import convert_to_pdf
+
 
 
 def test_convert_to_pdf_crea_archivo(monkeypatch, tmp_path):
@@ -46,4 +50,15 @@ def test_convert_to_pdf_levanta_called_process_error(monkeypatch, tmp_path):
 
     monkeypatch.setattr("modules.common.libreoffice_export.subprocess.run", fake_run)
     with pytest.raises(subprocess.CalledProcessError):
+        convert_to_pdf(str(docx), "soffice")
+
+def test_convert_to_pdf_falla_si_no_se_genero_pdf(monkeypatch, tmp_path):
+    docx = tmp_path / "archivo.docx"
+    docx.write_text("contenido")
+
+    def fake_run(cmd, check, stdout, stderr):
+        pass
+
+    monkeypatch.setattr("modules.common.libreoffice_export.subprocess.run", fake_run)
+    with pytest.raises(FileNotFoundError):
         convert_to_pdf(str(docx), "soffice")

--- a/tests/test_web_metrics.py
+++ b/tests/test_web_metrics.py
@@ -1,0 +1,30 @@
+# Nombre de archivo: test_web_metrics.py
+# Ubicación de archivo: tests/test_web_metrics.py
+# Descripción: Pruebas del endpoint /metrics del servicio web
+
+from pathlib import Path
+import importlib
+import os
+import sys
+
+from fastapi.testclient import TestClient
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+sys.path.append(str(Path(__file__).resolve().parents[1] / "web"))
+
+
+def get_client() -> TestClient:
+    os.environ["WEB_ADMIN_USERNAME"] = "user"
+    os.environ["WEB_ADMIN_PASSWORD"] = "pass"
+    module = importlib.reload(importlib.import_module("main"))
+    return TestClient(module.app)
+
+
+def test_metrics_endpoint_devuelve_datos() -> None:
+    client = get_client()
+    client.get("/health")
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "total_requests" in data
+    assert "average_latency_ms" in data


### PR DESCRIPTION
## Resumen
- agregar acumulador simple de métricas
- exponer `/metrics` en servicios web y API
- reportar cobertura en CI con pytest-cov

## Pruebas
- `pytest` *(falla: tests/test_bot_conversations.py::test_conversacion_repetitividad)*
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a9e8456aa48330b88e3e4fca83cc80