### PR TITLE
Agregar AGENTS.md por módulo y actualizar documentación

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ las-focas/
 └─ README.md
 ```
 
+## 📘 Guías por módulo
+
+Cada directorio principal incluye un archivo `AGENTS.md` con lineamientos específicos. Revísalo antes de modificar cualquier código. Para más detalles ver [docs/agents.md](docs/agents.md).
+
 ---
 
 ## 🔐 Configuración y credenciales

--- a/api/AGENTS.md
+++ b/api/AGENTS.md
@@ -1,0 +1,9 @@
+# Nombre de archivo: AGENTS.md
+# Ubicación de archivo: api/AGENTS.md
+# Descripción: Instrucciones específicas para el módulo API
+
+Este archivo complementa las pautas generales de LAS-FOCAS.
+
+- Mantener estilo PEP8 y encabezado de tres líneas.
+- Documentar endpoints y cambios en `docs/api.md`.
+- Añadir pruebas relacionadas en `tests`.

--- a/bot_telegram/AGENTS.md
+++ b/bot_telegram/AGENTS.md
@@ -1,0 +1,9 @@
+# Nombre de archivo: AGENTS.md
+# Ubicación de archivo: bot_telegram/AGENTS.md
+# Descripción: Instrucciones específicas para el bot de Telegram
+
+Este archivo complementa las pautas generales de LAS-FOCAS.
+
+- Mantener estilo PEP8 y encabezado de tres líneas.
+- Documentar flujos y comandos en `docs/bot.md`.
+- Añadir pruebas del bot en `tests`.

--- a/core/AGENTS.md
+++ b/core/AGENTS.md
@@ -1,0 +1,9 @@
+# Nombre de archivo: AGENTS.md
+# Ubicación de archivo: core/AGENTS.md
+# Descripción: Directrices para el núcleo del proyecto
+
+Este archivo complementa las pautas generales de LAS-FOCAS.
+
+- Mantener arquitectura modular y encabezado de tres líneas.
+- Documentar ajustes relevantes en `docs/decisiones.md`.
+- Asegurar cobertura de pruebas en `tests`.

--- a/db/AGENTS.md
+++ b/db/AGENTS.md
@@ -1,0 +1,9 @@
+# Nombre de archivo: AGENTS.md
+# Ubicación de archivo: db/AGENTS.md
+# Descripción: Instrucciones para el módulo de base de datos
+
+Este archivo complementa las pautas generales de LAS-FOCAS.
+
+- Registrar cambios de esquema en `docs/db.md` y migraciones.
+- Mantener encabezado de tres líneas en archivos SQL o Python.
+- Incluir pruebas de integración en `tests` cuando corresponda.

--- a/deploy/AGENTS.md
+++ b/deploy/AGENTS.md
@@ -1,0 +1,9 @@
+# Nombre de archivo: AGENTS.md
+# Ubicación de archivo: deploy/AGENTS.md
+# Descripción: Guía para scripts de despliegue
+
+Este archivo complementa las pautas generales de LAS-FOCAS.
+
+- Documentar cambios de infraestructura en `docs/infra.md`.
+- Evitar usar `latest` en imágenes de Docker.
+- Mantener encabezado de tres líneas en nuevos archivos.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,9 @@
+# Nombre de archivo: AGENTS.md
+# Ubicación de archivo: docs/AGENTS.md
+# Descripción: Lineamientos para la documentación del proyecto
+
+Este archivo complementa las pautas generales de LAS-FOCAS.
+
+- Cada documento debe iniciar con el encabezado de tres líneas.
+- Mantener la documentación sincronizada con el código y requerimientos.
+- Registrar decisiones técnicas en `docs/decisiones.md`.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,9 @@
+# Nombre de archivo: agents.md
+# Ubicación de archivo: docs/agents.md
+# Descripción: Guía de archivos AGENTS.md por módulo
+
+Cada módulo clave de LAS-FOCAS contiene un archivo `AGENTS.md` con instrucciones específicas.
+
+- Revisar siempre el `AGENTS.md` del módulo antes de modificar código.
+- Mantener documentación y pruebas alineadas con las pautas del módulo.
+- Si se crea un módulo nuevo, incluir su propio `AGENTS.md` y actualizar este documento.

--- a/integrations/AGENTS.md
+++ b/integrations/AGENTS.md
@@ -1,0 +1,9 @@
+# Nombre de archivo: AGENTS.md
+# Ubicación de archivo: integrations/AGENTS.md
+# Descripción: Instrucciones para integraciones externas
+
+Este archivo complementa las pautas generales de LAS-FOCAS.
+
+- Documentar nuevas integraciones y credenciales en `docs/integrations.md`.
+- Mantener encabezado de tres líneas y manejar secretos mediante `.env` o Docker Secrets.
+- Incluir pruebas o mocks en `tests` si se agregan integraciones.

--- a/modules/AGENTS.md
+++ b/modules/AGENTS.md
@@ -1,0 +1,9 @@
+# Nombre de archivo: AGENTS.md
+# Ubicación de archivo: modules/AGENTS.md
+# Descripción: Directrices para los módulos funcionales
+
+Este archivo complementa las pautas generales de LAS-FOCAS.
+
+- Mantener encabezado de tres líneas en cada archivo de módulo.
+- Alinear cada módulo con la documentación en `docs/informes` u otras secciones pertinentes.
+- Añadir pruebas en `tests` para cada módulo nuevo o modificado.

--- a/nlp_intent/AGENTS.md
+++ b/nlp_intent/AGENTS.md
@@ -1,0 +1,9 @@
+# Nombre de archivo: AGENTS.md
+# Ubicación de archivo: nlp_intent/AGENTS.md
+# Descripción: Instrucciones para el microservicio de NLP
+
+Este archivo complementa las pautas generales de LAS-FOCAS.
+
+- Registrar modelos y cambios en `docs/nlp/intent.md`.
+- Mantener encabezado de tres líneas y estilo PEP8.
+- Incluir pruebas específicas en `tests` para el microservicio.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,9 @@
+# Nombre de archivo: AGENTS.md
+# Ubicación de archivo: tests/AGENTS.md
+# Descripción: Convenciones para las pruebas del proyecto
+
+Este archivo complementa las pautas generales de LAS-FOCAS.
+
+- Usar `pytest` como marco de pruebas.
+- Mantener encabezado de tres líneas en cada archivo de test.
+- Buscar una cobertura mínima del 60% en módulos nuevos.

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -1,0 +1,9 @@
+# Nombre de archivo: AGENTS.md
+# Ubicación de archivo: web/AGENTS.md
+# Descripción: Instrucciones para el panel web
+
+Este archivo complementa las pautas generales de LAS-FOCAS.
+
+- Documentar vistas y cambios en `docs/web.md`.
+- Mantener encabezado de tres líneas y estilo PEP8.
+- Añadir pruebas relacionadas en `tests`.


### PR DESCRIPTION
## Resumen
- Crear AGENTS.md en módulos clave (api, bot_telegram, core, db, deploy, docs, integrations, modules, nlp_intent, tests, web)
- Añadir guía central docs/agents.md
- Actualizar README con referencia a AGENTS

## Testing
- `pip install -r requirements.txt`
- `ruff check .`
- `pytest` (falla 1 prueba: tests/test_bot_conversations.py::test_conversacion_repetitividad)


------
https://chatgpt.com/codex/tasks/task_e_68a9eac0ed9c8330b3d3d800a927fcba