### PR TITLE
[bot] Mejora flujo SLA con horario laboral y PDF

### DIFF
--- a/docs/bot.md
+++ b/docs/bot.md
@@ -9,6 +9,8 @@
 - INTENT_THRESHOLD=0.7  # Umbral mínimo de confianza para aceptar una intención
 - BOT_RATE_LIMIT=20       # Máximo de mensajes por usuario
 - BOT_RATE_INTERVAL=60    # Ventana en segundos para el límite
+- WORK_HOURS=false        # "true" calcula SLA en horario laboral
+- SOFFICE_BIN=/usr/bin/soffice  # Opcional, habilita PDF
 
 ## Arranque con Docker
 
@@ -17,7 +19,7 @@ que los flujos `/sla` y `/repetitividad` funcionen correctamente.
 
 La imagen incluye LibreOffice en modo headless, lo que permite convertir los
 reportes a PDF siempre que se defina `SOFFICE_BIN=/usr/bin/soffice` en el
-entorno.
+entorno. Si falta, el bot informa que no se generará PDF.
 
 ```bash
 docker compose -f deploy/compose.yml up -d --build bot

--- a/docs/informes/sla.md
+++ b/docs/informes/sla.md
@@ -19,8 +19,8 @@ Mapeos admitidos: `TicketID`→`ID`, `Apertura`→`FECHA_APERTURA`, `Cierre`→`
 
 ## Cálculo
 - Se normalizan las columnas y se calcula `TTR_h = (FECHA_CIERRE - FECHA_APERTURA) / 3600`.
-- Si `WORK_HOURS=true` se aplica un cálculo alternativo de TTR basado en horario laboral (por ahora reducido al 50 % como *placeholder*).
-- Ejemplo: un ticket abierto a las 08:00 y cerrado a las 20:00 computa 6 h de TTR en lugar de 12 h.
+- Si `WORK_HOURS=true` se calcula el TTR sólo en días hábiles (lunes a viernes) entre las 09:00 y las 18:00.
+- Ejemplo: un ticket abierto a las 08:00 y cerrado a las 20:00 computa 9 h de TTR.
 - Se filtra por `FECHA_CIERRE` dentro del período indicado (mes/año).
 - Si falta `SLA_OBJETIVO_HORAS`, se usa `SLA_POR_SERVICIO` con fallback **24 h**.
 - Se excluyen casos sin fecha de cierre y se informa la cantidad excluida.
@@ -48,5 +48,5 @@ Mapeos admitidos: `TicketID`→`ID`, `Apertura`→`FECHA_APERTURA`, `Cierre`→`
 - `SLA_TEMPLATE_PATH=/app/templates/sla.docx` ruta de la plantilla.
 - `REPORTS_DIR=/app/data/reports` destino de los informes.
 - `UPLOADS_DIR=/app/data/uploads` ubicación temporal de archivos subidos.
-- `SOFFICE_BIN=/usr/bin/soffice` habilita la exportación a PDF. LibreOffice ya está instalado en la imagen del bot.
-- `WORK_HOURS=false` usa horas calendario; en `true` habilita cálculo de TTR en horario laboral (placeholder).
+- `SOFFICE_BIN=/usr/bin/soffice` habilita la exportación a PDF. Si falta, se informa que sólo se genera DOCX.
+- `WORK_HOURS=false` usa horas calendario; en `true` habilita cálculo de TTR en horario laboral.

--- a/modules/informes_sla/report.py
+++ b/modules/informes_sla/report.py
@@ -97,6 +97,7 @@ def export_docx(data: ResultadoSLA, periodo: Params, out_dir: str) -> str:
     out_path.mkdir(parents=True, exist_ok=True)
     docx_path = out_path / f"sla_{periodo.periodo_anio}{periodo.periodo_mes:02d}.docx"
     doc.save(docx_path)
+    docx_path.chmod(0o600)
     logger.info("action=export_docx path=%s", docx_path)
     return str(docx_path)
 
@@ -106,7 +107,9 @@ def maybe_export_pdf(docx_path: str, soffice_bin: Optional[str]) -> Optional[str
     if not soffice_bin:
         return None
     try:
-        return convert_to_pdf(docx_path, soffice_bin)
+        pdf_path = convert_to_pdf(docx_path, soffice_bin)
+        Path(pdf_path).chmod(0o600)
+        return pdf_path
     except (FileNotFoundError, subprocess.CalledProcessError):  # pragma: no cover - logging
         logger.exception("action=maybe_export_pdf error")
         return None

--- a/modules/informes_sla/runner.py
+++ b/modules/informes_sla/runner.py
@@ -39,6 +39,8 @@ def run(file_path: str, mes: int, anio: int, soffice_bin: Optional[str]) -> Dict
         except Exception:
             logger.exception("action=run error_pdf")
             error_pdf = "No se pudo convertir a PDF"
+    else:
+        error_pdf = "LibreOffice no configurado; se omitió el PDF"
 
     logger.info(
         "action=run mes=%s anio=%s docx=%s pdf=%s total=%s incumplidos=%s pct_cumplimiento=%.2f excluidos=%s",


### PR DESCRIPTION
## Resumen
- Calcula TTR en horario laboral para el informe de SLA y ajusta permisos de archivos generados.
- Manejo explícito cuando LibreOffice no está disponible e información al usuario desde el bot.
- Pruebas ampliadas para horario laboral, permisos y conversión a PDF; documentación actualizada.

## Testing
- `PYTHONPATH=. pytest tests/test_sla_processor.py tests/test_sla_report_builder.py -q`
- `PYTHONPATH=. pytest tests/test_bot_conversations.py::test_conversacion_sla -q` *(falla: KeyboardInterrupt)*


------
https://chatgpt.com/codex/tasks/task_e_68a9faea0ec08330beec4535c7bfb773