### PR TITLE
[db/docs] Roles mínimos y rotación documentada

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -43,6 +43,19 @@ CREATE TABLE IF NOT EXISTS app.api_keys (
 CREATE INDEX IF NOT EXISTS idx_messages_user ON app.messages(tg_user_id);
 CREATE INDEX IF NOT EXISTS idx_messages_created ON app.messages(created_at);
 
+-- Usuario de aplicación con privilegios mínimos
+CREATE USER lasfocas_app WITH ENCRYPTED PASSWORD 'app';
+
+-- Revocar privilegios por defecto
+REVOKE ALL PRIVILEGES ON DATABASE lasfocas FROM PUBLIC;
+REVOKE ALL ON SCHEMA app FROM PUBLIC;
+
+-- Otorgar privilegios mínimos al usuario de aplicación
+GRANT CONNECT ON DATABASE lasfocas TO lasfocas_app;
+GRANT USAGE ON SCHEMA app TO lasfocas_app;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA app TO lasfocas_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA app GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO lasfocas_app;
+
 -- Usuario de solo lectura para consultas
 CREATE USER lasfocas_readonly WITH ENCRYPTED PASSWORD 'readonly';
 

--- a/docs/db.md
+++ b/docs/db.md
@@ -19,14 +19,14 @@ para verificar el estado de la base de datos.
 
 Se limpiaron imports innecesarios en los repositorios de conversaciones y mensajes para mantener el código conforme a PEP8.
 
-## Usuario de solo lectura
+## Usuarios de la base
 
-El script `db/init.sql` crea el usuario `lasfocas_readonly` con permisos restringidos:
+El script `db/init.sql` define dos roles diferenciados:
 
-- Conexión únicamente a la base `lasfocas`.
-- Acceso `SELECT` sobre todas las tablas del esquema `app`.
+- `lasfocas_app`: usuario de aplicación con privilegios `SELECT`, `INSERT`, `UPDATE` y `DELETE` sobre el esquema `app`.
+- `lasfocas_readonly`: usuario con acceso exclusivo de lectura para consultas y dashboards.
 
-Este usuario permite realizar consultas y dashboards sin riesgo de modificación de datos.
+Ambos usuarios solo pueden conectarse a la base `lasfocas` y se revocan los permisos predeterminados a `PUBLIC` para aplicar el principio de mínimo privilegio.
 
 ## Tabla api_keys
 
@@ -46,4 +46,4 @@ Pasos básicos para trabajar con migraciones:
 2. Editar el archivo creado en `db/migrations/versions/` agregando el encabezado requerido y las operaciones deseadas.
 3. Aplicar los cambios: `alembic upgrade head`.
 
-La revisión inicial ejecuta el contenido de `db/init.sql`, creando el esquema `app` junto con el usuario de solo lectura.
+La revisión inicial ejecuta el contenido de `db/init.sql`, creando el esquema `app` y los usuarios de aplicación y solo lectura.

--- a/docs/infra.md
+++ b/docs/infra.md
@@ -33,6 +33,18 @@
 - `nlp_intent`: límite de `1` CPU y `1GB` de RAM debido al procesamiento de lenguaje natural.
 - `ollama`: límite de `1` CPU y `2GB` de RAM para el servicio de modelos LLM.
 
+## Perfiles opcionales
+
+- `worker`: habilita `redis` y el servicio de tareas en segundo plano.
+- `pgadmin`: expone una interfaz web para administración de PostgreSQL.
+  Se activa con `docker compose -f deploy/compose.yml --profile pgadmin up -d`.
+
+## Política de rotación
+
+Las credenciales montadas como secrets deben rotarse cada 90 días.
+La actualización del archivo en `deploy/secrets/` y el redeploy del servicio bastan para aplicar la rotación.
+Para más detalles consultar `docs/security.md`.
+
 ## Seguridad
 
 - `api`, `bot`, `web` y `worker` se ejecutan con un usuario no root dentro de sus contenedores, aplicando el principio de mínimos privilegios.

--- a/docs/security.md
+++ b/docs/security.md
@@ -14,6 +14,12 @@
 - Para rotar un secreto, actualizar el archivo correspondiente y volver a desplegar el servicio que lo consume.
 - No se deben exponer tokens ni contraseñas en logs ni commits.
 
+### Política de rotación
+
+- Todos los secretos y credenciales deben rotarse al menos cada 90 días.
+- La rotación incluye los servicios activados mediante perfiles opcionales como `worker` o `pgadmin`.
+- Registrar en `docs/decisiones.md` cualquier rotación que implique cambios operativos.
+
 ## Rate limiting
 
 - Cada servicio debe definir límites de solicitudes por origen. Ejemplo: `API_RATE_LIMIT=60/minute`.


### PR DESCRIPTION
## Resumen
- Agregar usuarios de aplicación y solo lectura con privilegios mínimos en la base
- Documentar políticas de rotación de secrets y perfiles opcionales en la infraestructura
- Registrar nuevos roles de base en la documentación

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa309a59648330bcfd025978eb33a7