### PR TITLE
[infra] Añadir healthchecks y límites de recursos faltantes

### DIFF
--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -160,6 +160,11 @@ services:
       - postgres
       - redis
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "python -c 'import os'"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
     deploy:
       resources:
         limits:
@@ -178,6 +183,11 @@ services:
     restart: unless-stopped
     expose:
       - "6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
     deploy:
       resources:
         limits:
@@ -219,6 +229,16 @@ services:
       PGADMIN_DEFAULT_PASSWORD: admin
     ports:
       - "5050:80"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:80/login || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+    deploy:
+      resources:
+        limits:
+          cpus: "0.25"
+          memory: "256M"
     depends_on:
       - postgres
     networks:

--- a/docs/infra.md
+++ b/docs/infra.md
@@ -32,6 +32,19 @@
 - `redis`: límite de `0.25` CPU y `128MB` de RAM; solo se inicia con el perfil `worker`.
 - `nlp_intent`: límite de `1` CPU y `1GB` de RAM debido al procesamiento de lenguaje natural.
 - `ollama`: límite de `1` CPU y `2GB` de RAM para el servicio de modelos LLM.
+- `pgadmin`: límite de `0.25` CPU y `256MB` de RAM; se usa solo para administración.
+
+## Healthchecks
+
+- `postgres`: ejecuta `pg_isready` para confirmar que la base responde.
+- `api`: solicita `http://localhost:8000/health`.
+- `web`: consulta `http://localhost:8080/health`.
+- `nlp_intent`: corre `healthcheck.sh` interno.
+- `bot`: ejecuta `healthcheck.sh` propio del bot.
+- `worker`: realiza `python -c 'import os'` como verificación simple del intérprete.
+- `redis`: usa `redis-cli ping` para confirmar disponibilidad.
+- `ollama`: consulta `http://localhost:11434/api/tags`.
+- `pgadmin`: consulta `http://localhost:80/login`.
 
 ## Perfiles opcionales
 


### PR DESCRIPTION
## Resumen
- agregar healthcheck al worker y redis
- agregar healthcheck y límites de recursos a pgadmin
- documentar parámetros de recursos y healthchecks

## Pruebas
- `docker compose -f deploy/compose.yml up -d` (falla: el comando compose no está disponible en la imagen de Docker instalada)
- `docker compose ps` (falla: el comando compose no está disponible)
- `docker-compose -f deploy/compose.yml up -d` (falla: la versión de docker-compose no soporta la clave `name`)


------
https://chatgpt.com/codex/tasks/task_e_68ab57b413988330b5b77eb07190d137