### PR TITLE
[nlp_intent] Permite cambiar proveedor LLM via endpoint /config

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -16,6 +16,7 @@ TELEGRAM_BOT_TOKEN=
 TELEGRAM_ALLOWED_IDS=11111111,22222222
 
 # NLP / LLM
+# Proveedor por defecto (auto, heuristic, ollama, openai)
 LLM_PROVIDER=auto
 OPENAI_API_KEY=
 # Se carga desde /run/secrets/openai_api_key cuando está disponible

--- a/docs/nlp/intent.md
+++ b/docs/nlp/intent.md
@@ -9,7 +9,9 @@ Servicio FastAPI para clasificar mensajes de usuario en una de tres intenciones:
 ## Endpoint
 
 - `POST /v1/intent:classify`
+- `GET /config` y `POST /config`
 - `GET /metrics`
+- `GET /health`
 
 ### Request
 ```json
@@ -47,6 +49,29 @@ comprender mejor la intención.
 3. OpenAI API.
 
 El servicio intenta cada proveedor en ese orden mientras la confianza sea menor al umbral configurado (`INTENT_THRESHOLD`, por defecto **0.7**).
+
+## Configuración del proveedor LLM
+
+El proveedor por defecto se define mediante la variable `LLM_PROVIDER`.
+Valores admitidos: `auto`, `heuristic`, `ollama` y `openai`.
+
+El endpoint `/config` permite consultar o modificar este valor en tiempo de ejecución.
+
+### `GET /config`
+
+Devuelve el proveedor configurado:
+
+```json
+{ "llm_provider": "heuristic" }
+```
+
+### `POST /config`
+
+Actualiza el proveedor activo:
+
+```json
+{ "llm_provider": "openai" }
+```
 
 ## Caché
 

--- a/nlp_intent/app/main.py
+++ b/nlp_intent/app/main.py
@@ -10,9 +10,11 @@ import time
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.util import get_remote_address
 from slowapi.errors import RateLimitExceeded
+import logging
 
-from .schemas import IntentRequest, IntentResponse
+from .schemas import IntentRequest, IntentResponse, ProviderConfig
 from .service import classify_text
+from .config import settings
 from .metrics import (
     CONTENT_TYPE_LATEST,
     export_metrics,
@@ -22,6 +24,7 @@ from core.logging import configure_logging
 from core.middlewares import RequestIDMiddleware
 
 configure_logging("nlp_intent")
+logger = logging.getLogger(__name__)
 
 limiter = Limiter(key_func=get_remote_address)
 app = FastAPI(title="nlp_intent")
@@ -46,6 +49,20 @@ async def collect_metrics(request: Request, call_next):
 async def classify_endpoint(request: Request, req: IntentRequest) -> IntentResponse:
     """Clasifica el texto recibido en una intención."""
     return await classify_text(req.text)
+
+
+@app.get("/config", response_model=ProviderConfig)
+async def get_config() -> ProviderConfig:
+    """Devuelve el proveedor LLM actualmente configurado."""
+    return ProviderConfig(llm_provider=settings.llm_provider)
+
+
+@app.post("/config", response_model=ProviderConfig)
+async def set_config(cfg: ProviderConfig) -> ProviderConfig:
+    """Actualiza el proveedor LLM en tiempo de ejecución."""
+    settings.llm_provider = cfg.llm_provider
+    logger.info("llm_provider_actualizado", extra={"llm_provider": cfg.llm_provider})
+    return ProviderConfig(llm_provider=settings.llm_provider)
 
 
 @app.get("/metrics")

--- a/nlp_intent/app/schemas.py
+++ b/nlp_intent/app/schemas.py
@@ -25,3 +25,9 @@ class IntentResponse(BaseModel):
         orm_mode = True
 
 
+class ProviderConfig(BaseModel):
+    llm_provider: Literal["auto", "heuristic", "ollama", "openai"] = Field(
+        ..., description="Proveedor LLM activo"
+    )
+
+

--- a/nlp_intent/tests/test_intent.py
+++ b/nlp_intent/tests/test_intent.py
@@ -9,8 +9,11 @@ import asyncio
 import pathlib
 import sys
 
+from fastapi.testclient import TestClient
+
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
-from nlp_intent.app.service import classify_text, cache
+from nlp_intent.app import service, main
+from nlp_intent.app.schemas import IntentResponse
 
 TEST_DATA = [
     ("hola", "Otros"),
@@ -30,17 +33,54 @@ TEST_DATA = [
 
 def test_dataset_accuracy(monkeypatch):
     monkeypatch.setenv("LLM_PROVIDER", "heuristic")
-    cache.clear()
+    service.settings.llm_provider = "heuristic"
+    service.cache.clear()
+    service.disabled_providers.clear()
+    service.failure_counts["openai"] = 0
+    service.failure_counts["ollama"] = 0
 
     async def _run():
         hits = 0
         for text, expected in TEST_DATA:
-            resp = await classify_text(text)
+            resp = await service.classify_text(text)
             if resp.intent == expected:
                 hits += 1
         return hits / len(TEST_DATA)
 
     accuracy = asyncio.run(_run())
     assert accuracy >= 0.9
+
+
+def test_config_endpoint_changes_provider(monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER", "heuristic")
+    service.settings.llm_provider = "heuristic"
+    service.cache.clear()
+    service.disabled_providers.clear()
+    service.failure_counts["openai"] = 0
+    service.failure_counts["ollama"] = 0
+    client = TestClient(main.app)
+
+    resp = client.post("/config", json={"llm_provider": "heuristic"})
+    assert resp.status_code == 200
+    assert resp.json() == {"llm_provider": "heuristic"}
+
+    resp = client.post("/v1/intent:classify", json={"text": "hola 1"})
+    assert resp.json()["provider"] == "heuristic"
+
+    async def fake_openai(text: str, normalized: str) -> IntentResponse:
+        return IntentResponse(
+            intent="Consulta",
+            confidence=1.0,
+            provider="openai",
+            normalized_text=normalized,
+        )
+
+    monkeypatch.setattr(service.openai_provider, "classify", fake_openai)
+    resp = client.post("/config", json={"llm_provider": "openai"})
+    assert resp.status_code == 200
+    service.cache.clear()
+    resp = client.post("/v1/intent:classify", json={"text": "hola 2"})
+    assert resp.json()["provider"] == "openai"
+    main.limiter.reset()
 
 


### PR DESCRIPTION
## Resumen
- Se agrega endpoint `/config` para consultar y modificar el proveedor LLM en tiempo de ejecución.
- Se documentan los nuevos endpoints y opciones de `LLM_PROVIDER`.
- Se añaden pruebas que validan el cambio dinámico de proveedor.

## Pruebas
- `pytest nlp_intent/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab5c29029c8330a6c2f761db16422b