### PR TITLE
Verificación de soffice y pasos para exportar PDF

### DIFF
--- a/docs/informes/repetitividad.md
+++ b/docs/informes/repetitividad.md
@@ -42,3 +42,8 @@
 - `SOFFICE_BIN=/usr/bin/soffice` habilita la conversión a PDF. LibreOffice ya está instalado en la imagen del bot.
 - `MAPS_ENABLED=false` habilita mapas cuando es `true`.
 - `MAPS_LIGHTWEIGHT=true` usa Matplotlib sin stack geoespacial.
+
+## Habilitar exportación a PDF
+1. Instalar LibreOffice: `apt-get install -y libreoffice`.
+2. Verificar la ruta del binario con `which soffice`.
+3. Definir la variable de entorno `SOFFICE_BIN` con la ruta obtenida.

--- a/docs/informes/sla.md
+++ b/docs/informes/sla.md
@@ -50,3 +50,8 @@ Mapeos admitidos: `TicketID`→`ID`, `Apertura`→`FECHA_APERTURA`, `Cierre`→`
 - `UPLOADS_DIR=/app/data/uploads` ubicación temporal de archivos subidos.
 - `SOFFICE_BIN=/usr/bin/soffice` habilita la exportación a PDF. Si falta, se informa que sólo se genera DOCX.
 - `WORK_HOURS=false` usa horas calendario; en `true` habilita cálculo de TTR en horario laboral.
+
+## Habilitar exportación a PDF
+1. Instalar LibreOffice: `apt-get install -y libreoffice`.
+2. Confirmar la ruta del binario con `which soffice`.
+3. Definir `SOFFICE_BIN` con la ruta verificada.

--- a/modules/common/libreoffice_export.py
+++ b/modules/common/libreoffice_export.py
@@ -3,6 +3,7 @@
 # Descripción: Conversión de archivos DOCX a PDF usando LibreOffice en modo headless
 
 import logging
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -30,6 +31,11 @@ def convert_to_pdf(docx_path: str, soffice_bin: str) -> str:
         Propaga cualquier error ocurrido durante la conversión.
     """
     out_dir = Path(docx_path).parent
+    if not shutil.which(soffice_bin):
+        logger.error(
+            "action=convert_to_pdf error=soffice_no_encontrado path=%s", soffice_bin
+        )
+        raise FileNotFoundError(soffice_bin)
     try:
         subprocess.run(
             [

--- a/tests/test_libreoffice_export.py
+++ b/tests/test_libreoffice_export.py
@@ -23,6 +23,7 @@ def test_convert_to_pdf_crea_archivo(monkeypatch, tmp_path):
         pdf_esperado.write_text("pdf")
 
     monkeypatch.setattr("modules.common.libreoffice_export.subprocess.run", fake_run)
+    monkeypatch.setattr("modules.common.libreoffice_export.shutil.which", lambda _: "soffice")
 
     ruta_pdf = convert_to_pdf(str(docx), "soffice")
     assert Path(ruta_pdf) == pdf_esperado
@@ -33,10 +34,9 @@ def test_convert_to_pdf_levanta_file_not_found(monkeypatch, tmp_path):
     docx = tmp_path / "archivo.docx"
     docx.write_text("contenido")
 
-    def fake_run(cmd, check, stdout, stderr):  # pragma: no cover - logging
-        raise FileNotFoundError("soffice")
-
-    monkeypatch.setattr("modules.common.libreoffice_export.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "modules.common.libreoffice_export.shutil.which", lambda _: None
+    )
     with pytest.raises(FileNotFoundError):
         convert_to_pdf(str(docx), "soffice")
 
@@ -49,6 +49,7 @@ def test_convert_to_pdf_levanta_called_process_error(monkeypatch, tmp_path):
         raise subprocess.CalledProcessError(1, cmd, stderr=b"fallo")
 
     monkeypatch.setattr("modules.common.libreoffice_export.subprocess.run", fake_run)
+    monkeypatch.setattr("modules.common.libreoffice_export.shutil.which", lambda _: "soffice")
     with pytest.raises(subprocess.CalledProcessError):
         convert_to_pdf(str(docx), "soffice")
 
@@ -60,5 +61,6 @@ def test_convert_to_pdf_falla_si_no_se_genero_pdf(monkeypatch, tmp_path):
         pass
 
     monkeypatch.setattr("modules.common.libreoffice_export.subprocess.run", fake_run)
+    monkeypatch.setattr("modules.common.libreoffice_export.shutil.which", lambda _: "soffice")
     with pytest.raises(FileNotFoundError):
         convert_to_pdf(str(docx), "soffice")

--- a/tests/test_report_builder.py
+++ b/tests/test_report_builder.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from docx import Document
 
-from modules.informes_repetitividad.report import export_docx
+from modules.informes_repetitividad.report import export_docx, maybe_export_pdf
 from modules.informes_repetitividad.schemas import ItemSalida, Params, ResultadoRepetitividad
 
 
@@ -21,3 +21,20 @@ def test_export_docx_crea_archivo(tmp_path):
     assert Path(path).exists()
     doc = Document(path)
     assert "Julio 2024" in doc.paragraphs[0].text
+
+
+def test_maybe_export_pdf_sin_soffice(tmp_path):
+    docx = tmp_path / "archivo.docx"
+    docx.write_text("doc")
+    assert maybe_export_pdf(str(docx), None) is None
+
+
+def test_maybe_export_pdf_ok(monkeypatch, tmp_path):
+    docx = tmp_path / "archivo.docx"
+    docx.write_text("doc")
+    pdf = tmp_path / "archivo.pdf"
+    monkeypatch.setattr(
+        "modules.informes_repetitividad.report.convert_to_pdf",
+        lambda d, s: str(pdf),
+    )
+    assert maybe_export_pdf(str(docx), "soffice") == str(pdf)


### PR DESCRIPTION
## Resumen
- Verificación explícita del binario `soffice` antes de convertir archivos DOCX a PDF.
- Documentación de los pasos necesarios para habilitar la generación de PDF en los informes.
- Casos de prueba para la conversión opcional a PDF en los reportes de Repetitividad y SLA.

## Pruebas
- `pytest tests/test_libreoffice_export.py tests/test_report_builder.py tests/test_sla_report_builder.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab5dba46408330969d2b93258899d3