### PR TITLE
Sincronizar variables de entorno y documentación

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -54,6 +54,12 @@ WEB_LECTOR_USERNAME=lector
 WEB_LECTOR_PASSWORD=lectura
 # Se carga desde /run/secrets/web_lector_password cuando está disponible
 
+# Variables heredadas para compatibilidad con versiones anteriores
+WEB_USERNAME=
+# Se carga desde /run/secrets/web_username cuando está disponible
+WEB_PASSWORD=
+# Se carga desde /run/secrets/web_password cuando está disponible
+
 # Integraciones
 NOTION_TOKEN=
 # Se carga desde /run/secrets/notion_token cuando está disponible

--- a/deploy/env.sample
+++ b/deploy/env.sample
@@ -16,6 +16,7 @@ TELEGRAM_BOT_TOKEN=
 TELEGRAM_ALLOWED_IDS=11111111,22222222
 
 # NLP / LLM
+# Proveedor por defecto (auto, heuristic, ollama, openai)
 LLM_PROVIDER=auto
 OPENAI_API_KEY=
 # Se carga desde /run/secrets/openai_api_key cuando está disponible
@@ -53,6 +54,21 @@ WEB_LECTOR_USERNAME=lector
 WEB_LECTOR_PASSWORD=lectura
 # Se carga desde /run/secrets/web_lector_password cuando está disponible
 
+# Variables heredadas para compatibilidad con versiones anteriores
+WEB_USERNAME=
+# Se carga desde /run/secrets/web_username cuando está disponible
+WEB_PASSWORD=
+# Se carga desde /run/secrets/web_password cuando está disponible
+
 # Integraciones
 NOTION_TOKEN=
 # Se carga desde /run/secrets/notion_token cuando está disponible
+SMTP_HOST=
+# Se carga desde /run/secrets/smtp_host cuando está disponible
+SMTP_PORT=587
+SMTP_USER=
+# Se carga desde /run/secrets/smtp_user cuando está disponible
+SMTP_PASSWORD=
+# Se carga desde /run/secrets/smtp_password cuando está disponible
+SMTP_FROM=
+# Se carga desde /run/secrets/smtp_from cuando está disponible

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -7,3 +7,4 @@ Cada módulo clave de LAS-FOCAS contiene un archivo `AGENTS.md` con instruccione
 - Revisar siempre el `AGENTS.md` del módulo antes de modificar código.
 - Mantener documentación y pruebas alineadas con las pautas del módulo.
 - Si se crea un módulo nuevo, incluir su propio `AGENTS.md` y actualizar este documento.
+- El archivo `.env.sample` es la única fuente de verdad para variables de entorno; mantener sincronizados `deploy/env.sample` y la documentación.

--- a/docs/infra.md
+++ b/docs/infra.md
@@ -64,7 +64,9 @@ Para más detalles consultar `docs/security.md`.
 
 ## Variables de entorno
 
-Las credenciales sensibles (`POSTGRES_PASSWORD`, `TELEGRAM_BOT_TOKEN`, `OPENAI_API_KEY`, `SMTP_*`, `WEB_ADMIN_*`, `WEB_LECTOR_*` y `NOTION_TOKEN`) se obtienen desde archivos en `/run/secrets/` cuando se utilizan Docker Secrets.
+El archivo `.env.sample` es la fuente única de verdad para todas las variables de entorno. Este listado resume su propósito y origen.
+
+Las credenciales sensibles (`POSTGRES_PASSWORD`, `TELEGRAM_BOT_TOKEN`, `OPENAI_API_KEY`, `SMTP_*`, `WEB_ADMIN_*`, `WEB_LECTOR_*`, `WEB_PASSWORD` y `NOTION_TOKEN`) se obtienen desde archivos en `/run/secrets/` cuando se utilizan Docker Secrets.
 
 ### Base de datos
 - `POSTGRES_HOST`: host del contenedor de PostgreSQL.
@@ -98,3 +100,21 @@ Las credenciales sensibles (`POSTGRES_PASSWORD`, `TELEGRAM_BOT_TOKEN`, `OPENAI_A
 ### Rate limiting
 - `API_RATE_LIMIT`: límite de peticiones por minuto para la API.
 - `NLP_RATE_LIMIT`: límite de peticiones por minuto para nlp_intent.
+- `BOT_RATE_LIMIT`: cantidad de mensajes permitidos por intervalo para el bot.
+- `BOT_RATE_INTERVAL`: intervalo en segundos asociado a `BOT_RATE_LIMIT`.
+
+### Web Panel
+- `WEB_ADMIN_USERNAME`: usuario con permisos de administrador.
+- `WEB_ADMIN_PASSWORD`: contraseña del administrador.
+- `WEB_LECTOR_USERNAME`: usuario con permisos de lectura.
+- `WEB_LECTOR_PASSWORD`: contraseña del usuario de lectura.
+- `WEB_USERNAME`: usuario heredado para compatibilidad; equivale a `WEB_ADMIN_USERNAME`.
+- `WEB_PASSWORD`: contraseña heredada para compatibilidad; equivale a `WEB_ADMIN_PASSWORD`.
+
+### Integraciones
+- `NOTION_TOKEN`: token de acceso para la API de Notion.
+- `SMTP_HOST`: servidor SMTP utilizado para enviar correos.
+- `SMTP_PORT`: puerto del servidor SMTP.
+- `SMTP_USER`: usuario para autenticación SMTP.
+- `SMTP_PASSWORD`: contraseña del usuario SMTP.
+- `SMTP_FROM`: dirección de correo remitente por defecto.


### PR DESCRIPTION
## Resumen
- Añadidas variables heredadas `WEB_USERNAME` y `WEB_PASSWORD` y alineadas variables SMTP en los ejemplos de entorno.
- Declarado `.env.sample` como única fuente de verdad y ampliada la guía de variables en la documentación.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab65f3b9ec8330a46a71a2ea4143ba