### PR TITLE
[infra] Gestionar contraseñas con secrets y exponer web internamente

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -7,8 +7,12 @@ POSTGRES_HOST=postgres
 POSTGRES_PORT=5432
 POSTGRES_DB=lasfocas
 POSTGRES_USER=lasfocas
-POSTGRES_PASSWORD=
+POSTGRES_PASSWORD=cambiar-este-password
 # Se carga desde /run/secrets/postgres_password cuando está disponible
+POSTGRES_APP_USER=lasfocas_app
+POSTGRES_APP_PASSWORD=cambiar-este-password
+POSTGRES_READONLY_PASSWORD=cambiar-este-password
+# Se cargan desde /run/secrets/postgres_app_password y postgres_readonly_password
 
 # Bot de Telegram
 TELEGRAM_BOT_TOKEN=
@@ -47,11 +51,11 @@ BOT_RATE_INTERVAL=60
 # Web Panel
 WEB_ADMIN_USERNAME=admin
 # Se carga desde /run/secrets/web_admin_username cuando está disponible
-WEB_ADMIN_PASSWORD=changeme
+WEB_ADMIN_PASSWORD=cambiar-este-password
 # Se carga desde /run/secrets/web_admin_password cuando está disponible
 WEB_LECTOR_USERNAME=lector
 # Se carga desde /run/secrets/web_lector_username cuando está disponible
-WEB_LECTOR_PASSWORD=lectura
+WEB_LECTOR_PASSWORD=cambiar-esta-password
 # Se carga desde /run/secrets/web_lector_password cuando está disponible
 
 # Variables heredadas para compatibilidad con versiones anteriores
@@ -68,7 +72,7 @@ SMTP_HOST=
 SMTP_PORT=587
 SMTP_USER=
 # Se carga desde /run/secrets/smtp_user cuando está disponible
-SMTP_PASSWORD=
+SMTP_PASSWORD=cambiar-este-password
 # Se carga desde /run/secrets/smtp_password cuando está disponible
 SMTP_FROM=
 # Se carga desde /run/secrets/smtp_from cuando está disponible

--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ POSTGRES_DB=lasfocas
 POSTGRES_USER=lasfocas
 POSTGRES_PASSWORD=
 # Se carga desde /run/secrets/postgres_password cuando está disponible
+POSTGRES_APP_USER=lasfocas_app
+POSTGRES_APP_PASSWORD=
+POSTGRES_READONLY_PASSWORD=
+# Se cargan desde /run/secrets/postgres_app_password y postgres_readonly_password
 
 # Bot de Telegram
 TELEGRAM_BOT_TOKEN=

--- a/api/app/db.py
+++ b/api/app/db.py
@@ -12,8 +12,8 @@ logger = logging.getLogger(__name__)
 DB_HOST = getenv("POSTGRES_HOST", "postgres")
 DB_PORT = getenv("POSTGRES_PORT", "5432")
 DB_NAME = getenv("POSTGRES_DB", "lasfocas")
-DB_USER = getenv("POSTGRES_USER", "lasfocas")
-DB_PASS = get_secret("POSTGRES_PASSWORD", "cambiar-este-password")
+DB_USER = getenv("POSTGRES_APP_USER", getenv("POSTGRES_USER", "lasfocas_app"))
+DB_PASS = get_secret("POSTGRES_APP_PASSWORD", "cambiar-este-password")
 
 DSN = f"postgresql+psycopg://{DB_USER}:{DB_PASS}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
 

--- a/bot_telegram/handlers/intent.py
+++ b/bot_telegram/handlers/intent.py
@@ -46,8 +46,8 @@ def _get_conn() -> psycopg.Connection:
     return psycopg.connect(
         host=os.getenv("POSTGRES_HOST", "localhost"),
         dbname=os.getenv("POSTGRES_DB"),
-        user=os.getenv("POSTGRES_USER"),
-        password=get_secret("POSTGRES_PASSWORD"),
+        user=os.getenv("POSTGRES_APP_USER", os.getenv("POSTGRES_USER")),
+        password=get_secret("POSTGRES_APP_PASSWORD"),
     )
 
 

--- a/db/init.sql
+++ b/db/init.sql
@@ -42,26 +42,3 @@ CREATE TABLE IF NOT EXISTS app.api_keys (
 
 CREATE INDEX IF NOT EXISTS idx_messages_user ON app.messages(tg_user_id);
 CREATE INDEX IF NOT EXISTS idx_messages_created ON app.messages(created_at);
-
--- Usuario de aplicación con privilegios mínimos
-CREATE USER lasfocas_app WITH ENCRYPTED PASSWORD 'app';
-
--- Revocar privilegios por defecto
-REVOKE ALL PRIVILEGES ON DATABASE lasfocas FROM PUBLIC;
-REVOKE ALL ON SCHEMA app FROM PUBLIC;
-
--- Otorgar privilegios mínimos al usuario de aplicación
-GRANT CONNECT ON DATABASE lasfocas TO lasfocas_app;
-GRANT USAGE ON SCHEMA app TO lasfocas_app;
-GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA app TO lasfocas_app;
-ALTER DEFAULT PRIVILEGES IN SCHEMA app GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO lasfocas_app;
-
--- Usuario de solo lectura para consultas
-CREATE USER lasfocas_readonly WITH ENCRYPTED PASSWORD 'readonly';
-
--- Revocar y otorgar privilegios mínimos
-REVOKE ALL PRIVILEGES ON DATABASE lasfocas FROM lasfocas_readonly;
-GRANT CONNECT ON DATABASE lasfocas TO lasfocas_readonly;
-GRANT USAGE ON SCHEMA app TO lasfocas_readonly;
-GRANT SELECT ON ALL TABLES IN SCHEMA app TO lasfocas_readonly;
-ALTER DEFAULT PRIVILEGES IN SCHEMA app GRANT SELECT ON TABLES TO lasfocas_readonly;

--- a/db/init_users.sh
+++ b/db/init_users.sh
@@ -1,0 +1,27 @@
+# Nombre de archivo: init_users.sh
+# Ubicación de archivo: db/init_users.sh
+# Descripción: Crea usuarios de aplicación y solo lectura usando contraseñas de secrets
+#!/bin/bash
+set -e
+
+APP_PASS=$(cat "$POSTGRES_APP_PASSWORD_FILE")
+READONLY_PASS=$(cat "$POSTGRES_READONLY_PASSWORD_FILE")
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    -- Usuario de aplicación con privilegios mínimos
+    CREATE USER lasfocas_app WITH ENCRYPTED PASSWORD '${APP_PASS}';
+    REVOKE ALL PRIVILEGES ON DATABASE $POSTGRES_DB FROM PUBLIC;
+    REVOKE ALL ON SCHEMA app FROM PUBLIC;
+    GRANT CONNECT ON DATABASE $POSTGRES_DB TO lasfocas_app;
+    GRANT USAGE ON SCHEMA app TO lasfocas_app;
+    GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA app TO lasfocas_app;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA app GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO lasfocas_app;
+
+    -- Usuario de solo lectura para consultas
+    CREATE USER lasfocas_readonly WITH ENCRYPTED PASSWORD '${READONLY_PASS}';
+    REVOKE ALL PRIVILEGES ON DATABASE $POSTGRES_DB FROM lasfocas_readonly;
+    GRANT CONNECT ON DATABASE $POSTGRES_DB TO lasfocas_readonly;
+    GRANT USAGE ON SCHEMA app TO lasfocas_readonly;
+    GRANT SELECT ON ALL TABLES IN SCHEMA app TO lasfocas_readonly;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA app GRANT SELECT ON TABLES TO lasfocas_readonly;
+EOSQL

--- a/db/migrations/versions/0001_estructura_inicial.py
+++ b/db/migrations/versions/0001_estructura_inicial.py
@@ -30,4 +30,5 @@ def upgrade() -> None:
 def downgrade() -> None:
     """Eliminar esquema y usuario creados en la migración."""
     op.execute("DROP SCHEMA IF EXISTS app CASCADE;")
+    op.execute("DROP USER IF EXISTS lasfocas_app;")
     op.execute("DROP USER IF EXISTS lasfocas_readonly;")

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -14,13 +14,18 @@ services:
       POSTGRES_DB: ${POSTGRES_DB}
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
+      POSTGRES_APP_PASSWORD_FILE: /run/secrets/postgres_app_password
+      POSTGRES_READONLY_PASSWORD_FILE: /run/secrets/postgres_readonly_password
     expose:
       - "5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./db/init.sql:/docker-entrypoint-initdb.d/00-init.sql:ro
+      - ./db/init_users.sh:/docker-entrypoint-initdb.d/01-users.sh:ro
     secrets:
       - postgres_password
+      - postgres_app_password
+      - postgres_readonly_password
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB} -h localhost"]
       interval: 5s
@@ -63,7 +68,7 @@ services:
     networks:
       - lasfocas_net
     secrets:
-      - postgres_password
+      - postgres_app_password
       - smtp_host
       - smtp_user
       - smtp_password
@@ -78,8 +83,8 @@ services:
     restart: unless-stopped
     env_file:
       - .env
-    ports:
-      - "8080:8080"
+    expose:
+      - "8080"
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://localhost:8080/health || exit 1"]
       interval: 10s
@@ -136,7 +141,7 @@ services:
       - bot_data:/app/data
     secrets:
       - telegram_bot_token
-      - postgres_password
+      - postgres_app_password
     healthcheck:
       test: ["CMD-SHELL", "sh /app/bot_telegram/healthcheck.sh"]
       interval: 10s
@@ -173,7 +178,7 @@ services:
     networks:
       - lasfocas_net
     secrets:
-      - postgres_password
+      - postgres_app_password
       - notion_token
     profiles: ["worker"]
 
@@ -252,6 +257,10 @@ volumes:
 secrets:
   postgres_password:
     file: ./secrets/postgres_password
+  postgres_app_password:
+    file: ./secrets/postgres_app_password
+  postgres_readonly_password:
+    file: ./secrets/postgres_readonly_password
   telegram_bot_token:
     file: ./secrets/telegram_bot_token
   openai_api_key:

--- a/deploy/env.sample
+++ b/deploy/env.sample
@@ -7,8 +7,12 @@ POSTGRES_HOST=postgres
 POSTGRES_PORT=5432
 POSTGRES_DB=lasfocas
 POSTGRES_USER=lasfocas
-POSTGRES_PASSWORD=
+POSTGRES_PASSWORD=cambiar-este-password
 # Se carga desde /run/secrets/postgres_password cuando está disponible
+POSTGRES_APP_USER=lasfocas_app
+POSTGRES_APP_PASSWORD=cambiar-este-password
+POSTGRES_READONLY_PASSWORD=cambiar-este-password
+# Se cargan desde /run/secrets/postgres_app_password y postgres_readonly_password
 
 # Bot de Telegram
 TELEGRAM_BOT_TOKEN=
@@ -47,11 +51,11 @@ BOT_RATE_INTERVAL=60
 # Web Panel
 WEB_ADMIN_USERNAME=admin
 # Se carga desde /run/secrets/web_admin_username cuando está disponible
-WEB_ADMIN_PASSWORD=changeme
+WEB_ADMIN_PASSWORD=cambiar-este-password
 # Se carga desde /run/secrets/web_admin_password cuando está disponible
 WEB_LECTOR_USERNAME=lector
 # Se carga desde /run/secrets/web_lector_username cuando está disponible
-WEB_LECTOR_PASSWORD=lectura
+WEB_LECTOR_PASSWORD=cambiar-esta-password
 # Se carga desde /run/secrets/web_lector_password cuando está disponible
 
 # Variables heredadas para compatibilidad con versiones anteriores
@@ -68,7 +72,7 @@ SMTP_HOST=
 SMTP_PORT=587
 SMTP_USER=
 # Se carga desde /run/secrets/smtp_user cuando está disponible
-SMTP_PASSWORD=
+SMTP_PASSWORD=cambiar-este-password
 # Se carga desde /run/secrets/smtp_password cuando está disponible
 SMTP_FROM=
 # Se carga desde /run/secrets/smtp_from cuando está disponible

--- a/docs/db.md
+++ b/docs/db.md
@@ -8,9 +8,9 @@ La cadena DSN se construye a partir de variables de entorno:
 - `POSTGRES_HOST`: dirección del servidor de base de datos.
 - `POSTGRES_PORT`: puerto del servicio.
 - `POSTGRES_DB`: nombre de la base de datos.
-- `POSTGRES_USER`: usuario para la conexión.
-- `POSTGRES_PASSWORD`: contraseña del usuario.
-  Se lee desde la variable de entorno o el archivo `/run/secrets/postgres_password`.
+- `POSTGRES_APP_USER`: usuario de aplicación con permisos mínimos.
+- `POSTGRES_APP_PASSWORD`: contraseña del usuario de aplicación.
+  Se leen desde las variables de entorno o desde `/run/secrets/postgres_app_password`.
 
 En `deploy/compose.yml` la base de datos solo se expone a otros contenedores mediante `expose: 5432`, evitando publicar el puerto en el host.
 
@@ -21,12 +21,12 @@ Se limpiaron imports innecesarios en los repositorios de conversaciones y mensaj
 
 ## Usuarios de la base
 
-El script `db/init.sql` define dos roles diferenciados:
+El script `db/init.sql` crea el esquema y las tablas, mientras que `db/init_users.sh` se encarga de definir los roles:
 
 - `lasfocas_app`: usuario de aplicación con privilegios `SELECT`, `INSERT`, `UPDATE` y `DELETE` sobre el esquema `app`.
 - `lasfocas_readonly`: usuario con acceso exclusivo de lectura para consultas y dashboards.
 
-Ambos usuarios solo pueden conectarse a la base `lasfocas` y se revocan los permisos predeterminados a `PUBLIC` para aplicar el principio de mínimo privilegio.
+Ambos usuarios se crean con contraseñas provistas mediante los secrets `postgres_app_password` y `postgres_readonly_password`. Además, se revocan los permisos predeterminados a `PUBLIC` para aplicar el principio de mínimo privilegio.
 
 ## Tabla api_keys
 
@@ -46,4 +46,4 @@ Pasos básicos para trabajar con migraciones:
 2. Editar el archivo creado en `db/migrations/versions/` agregando el encabezado requerido y las operaciones deseadas.
 3. Aplicar los cambios: `alembic upgrade head`.
 
-La revisión inicial ejecuta el contenido de `db/init.sql`, creando el esquema `app` y los usuarios de aplicación y solo lectura.
+La revisión inicial ejecuta el contenido de `db/init.sql` y `db/init_users.sh`, creando el esquema `app` y los usuarios correspondientes.

--- a/docs/infra.md
+++ b/docs/infra.md
@@ -19,7 +19,7 @@
 
 - `postgres_data`: persiste los datos de la base en `/var/lib/postgresql/data`.
 - `bot_data`: almacena archivos y estados del bot en `/app/data`.
-- `./db/init.sql` se monta de forma de solo lectura para inicializar la base.
+- `./db/init.sql` y `./db/init_users.sh` se montan de forma de solo lectura para inicializar la base y crear usuarios.
 - `ollama_data`: guarda los modelos descargados en `/root/.ollama`.
 
 ## Recursos
@@ -61,19 +61,23 @@ Para más detalles consultar `docs/security.md`.
 ## Seguridad
 
 - `api`, `bot`, `web` y `worker` se ejecutan con un usuario no root dentro de sus contenedores, aplicando el principio de mínimos privilegios.
+- El servicio `web` solo expone el puerto `8080` dentro de la red interna; para publicarlo externamente se debe configurar un proxy inverso.
 
 ## Variables de entorno
 
 El archivo `.env.sample` es la fuente única de verdad para todas las variables de entorno. Este listado resume su propósito y origen.
 
-Las credenciales sensibles (`POSTGRES_PASSWORD`, `TELEGRAM_BOT_TOKEN`, `OPENAI_API_KEY`, `SMTP_*`, `WEB_ADMIN_*`, `WEB_LECTOR_*`, `WEB_PASSWORD` y `NOTION_TOKEN`) se obtienen desde archivos en `/run/secrets/` cuando se utilizan Docker Secrets.
+Las credenciales sensibles (`POSTGRES_PASSWORD`, `POSTGRES_APP_PASSWORD`, `POSTGRES_READONLY_PASSWORD`, `TELEGRAM_BOT_TOKEN`, `OPENAI_API_KEY`, `SMTP_*`, `WEB_ADMIN_*`, `WEB_LECTOR_*`, `WEB_PASSWORD` y `NOTION_TOKEN`) se obtienen desde archivos en `/run/secrets/` cuando se utilizan Docker Secrets.
 
 ### Base de datos
 - `POSTGRES_HOST`: host del contenedor de PostgreSQL.
 - `POSTGRES_PORT`: puerto interno donde escucha PostgreSQL.
 - `POSTGRES_DB`: nombre de la base de datos principal.
-- `POSTGRES_USER`: usuario con permisos completos.
-- `POSTGRES_PASSWORD`: contraseña del usuario de la base.
+- `POSTGRES_USER`: usuario administrador del contenedor.
+- `POSTGRES_PASSWORD`: contraseña del usuario administrador.
+- `POSTGRES_APP_USER`: usuario de aplicación con permisos mínimos.
+- `POSTGRES_APP_PASSWORD`: contraseña del usuario de aplicación.
+- `POSTGRES_READONLY_PASSWORD`: contraseña del usuario de solo lectura.
 
 ### Bot de Telegram
 - `TELEGRAM_BOT_TOKEN`: token otorgado por BotFather.

--- a/docs/security.md
+++ b/docs/security.md
@@ -5,10 +5,12 @@
 ## Secrets
 
 - Las credenciales se gestionan mediante **Docker Secrets** montados en `/run/secrets/*`.
-- Secretos usados: `postgres_password`, `telegram_bot_token`, `openai_api_key`, `smtp_host`, `smtp_user`, `smtp_password`, `smtp_from`, `web_admin_username`, `web_admin_password`, `web_lector_username`, `web_lector_password` y `notion_token`.
+- Secretos usados: `postgres_password`, `postgres_app_password`, `postgres_readonly_password`, `telegram_bot_token`, `openai_api_key`, `smtp_host`, `smtp_user`, `smtp_password`, `smtp_from`, `web_admin_username`, `web_admin_password`, `web_lector_username`, `web_lector_password` y `notion_token`.
 - Para crear un secreto, generar el archivo en `deploy/secrets/<nombre>`:
   ```bash
   echo "valor" > deploy/secrets/postgres_password
+  echo "valor" > deploy/secrets/postgres_app_password
+  echo "valor" > deploy/secrets/postgres_readonly_password
   ```
   Luego reiniciar los servicios con `docker compose -f deploy/compose.yml up -d`.
 - Para rotar un secreto, actualizar el archivo correspondiente y volver a desplegar el servicio que lo consume.
@@ -30,3 +32,4 @@
 - Los contenedores deben ejecutarse con usuarios no root cuando sea posible.
 - La base de datos utiliza usuarios específicos por servicio y roles de solo lectura cuando aplique.
 - Los puertos publicados al host se restringen únicamente a los necesarios.
+- El servicio `web` requiere un proxy inverso si se desea exponerlo fuera de la red interna.

--- a/docs/web.md
+++ b/docs/web.md
@@ -9,7 +9,7 @@ Proveer una interfaz web interna para ejecutar tareas y visualizar informes gene
 ## Stack propuesto
 
 - **FastAPI** con plantillas Jinja2 para renderizado de páginas.
-- Servidor **Uvicorn** detrás de un proxy opcional.
+- Servidor **Uvicorn** detrás de un proxy inverso opcional.
 - Consumo de la API interna mediante llamadas HTTP.
 
 ## Rutas iniciales
@@ -29,7 +29,7 @@ El repositorio incluye un microservicio en `web/main.py` que utiliza **FastAPI**
 - `GET /login` entrega un formulario de acceso aún en desarrollo.
 - `GET /metrics` expone métricas simples sin autenticación.
 
-Este servicio se construye con `web/Dockerfile` sobre la imagen `python:3.11-slim` y se despliega mediante `deploy/compose.yml` como servicio `web`, publicando el puerto `8080` al host.
+Este servicio se construye con `web/Dockerfile` sobre la imagen `python:3.11-slim` y se despliega mediante `deploy/compose.yml` como servicio `web`, exponiendo el puerto `8080` solo a la red interna. Para publicar externamente se requiere un proxy inverso.
 
 ## Logging
 


### PR DESCRIPTION
## Resumen
- Mover contraseñas de la base a variables seguras usando Docker secrets
- Exponer el servicio web solo en la red interna para forzar proxy inverso
- Documentar nuevas variables y secretos en la guía de seguridad e infraestructura

## Pruebas
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab694ce27c8330a2e8e0153c9bdbd8