### PR TITLE
[ci] Agrega pruebas y construcción de imágenes Docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,15 @@ jobs:
           path: coverage.xml
       - name: Ejecutar ruff
         run: ruff check .
+  build-images:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Configurar Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Construir imagen API
+        run: docker build -t las-focas-api:ci ./api
+      - name: Construir imagen Web
+        run: docker build -t las-focas-web:ci ./web

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -11,5 +11,10 @@ El proyecto ejecuta un flujo de **integración continua** mediante GitHub Action
 3. Ejecución de las **pruebas** con `pytest` generando reporte de cobertura.
 4. **Carga** del archivo `coverage.xml` como artefacto de la ejecución.
 5. Análisis de estilo y calidad de código con **`ruff`**.
+6. Construcción de las imágenes Docker de **API** y **Web**.
 
 La finalidad es garantizar que el código pase las pruebas automatizadas y cumpla las reglas de estilo antes de integrarse en la rama principal.
+
+## Pruebas en contenedores
+
+El job `build-images` compila las imágenes `las-focas-api:ci` y `las-focas-web:ci` usando `docker build`. Este paso detecta de forma temprana errores en los `Dockerfile` y asegura que los servicios puedan ejecutarse en contenedores.

--- a/nlp_intent/tests/test_config_endpoint.py
+++ b/nlp_intent/tests/test_config_endpoint.py
@@ -1,0 +1,35 @@
+# Nombre de archivo: test_config_endpoint.py
+# Ubicación de archivo: nlp_intent/tests/test_config_endpoint.py
+# Descripción: Pruebas para el endpoint /config del servicio de NLP
+
+import asyncio
+import pathlib
+import sys
+
+from httpx import AsyncClient, ASGITransport
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from nlp_intent.app.main import app
+from nlp_intent.app.config import settings
+
+
+def test_config_get_y_post() -> None:
+    original = settings.llm_provider
+
+    async def _run():
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/config")
+            assert resp.status_code == 200
+            assert resp.json() == {"llm_provider": original}
+
+            nuevo = "heuristic" if original != "heuristic" else "openai"
+            resp = await client.post("/config", json={"llm_provider": nuevo})
+            assert resp.status_code == 200
+            assert resp.json() == {"llm_provider": nuevo}
+
+            resp = await client.get("/config")
+            assert resp.json() == {"llm_provider": nuevo}
+
+    asyncio.run(_run())
+    settings.llm_provider = original

--- a/tests/test_api_metrics.py
+++ b/tests/test_api_metrics.py
@@ -7,8 +7,8 @@ import sys
 
 from fastapi.testclient import TestClient
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
-sys.path.append(str(Path(__file__).resolve().parents[1] / "api"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "api"))
 
 from app.main import create_app
 
@@ -22,3 +22,14 @@ def test_metrics_endpoint_muestra_datos() -> None:
     data = resp.json()
     assert "total_requests" in data
     assert "average_latency_ms" in data
+
+
+def test_metrics_incrementa_con_cada_solicitud() -> None:
+    app = create_app()
+    client = TestClient(app)
+    app.state.metrics.reset()
+    client.get("/health")
+    primera = client.get("/metrics").json()["total_requests"]
+    client.get("/health")
+    segunda = client.get("/metrics").json()["total_requests"]
+    assert segunda == primera + 2

--- a/tests/test_rate_limit_api.py
+++ b/tests/test_rate_limit_api.py
@@ -8,7 +8,7 @@ import sys
 
 from fastapi.testclient import TestClient
 
-sys.path.append(str(Path(__file__).resolve().parents[1] / 'api'))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'api'))
 os.environ['API_RATE_LIMIT'] = '2/minute'
 
 from app.main import create_app

--- a/tests/test_request_id.py
+++ b/tests/test_request_id.py
@@ -1,13 +1,19 @@
 # Nombre de archivo: test_request_id.py
+# Nombre de archivo: test_request_id.py
 # Ubicación de archivo: tests/test_request_id.py
 # Descripción: Verifica que los servicios FastAPI generen X-Request-ID
 
 import uuid
+from pathlib import Path
+import sys
 
 from fastapi.testclient import TestClient
 
-from api.app.main import app as api_app
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "api"))
+from app.main import create_app
 from nlp_intent.app.main import app as nlp_app
+
+api_app = create_app()
 
 
 def _assert_request_id(client: TestClient, path: str) -> None:

--- a/tests/test_worker_async.py
+++ b/tests/test_worker_async.py
@@ -29,3 +29,15 @@ def test_worker_procesa_job(monkeypatch):
 
     job.refresh()
     assert job.result == 3
+
+
+def test_enqueue_informe_devuelve_job(monkeypatch):
+    """Verifica que la función retorne un job en la cola correcta."""
+    redis = fakeredis.FakeRedis()
+    queue = Queue("informes", connection=redis)
+    monkeypatch.setattr(worker, "redis_conn", redis)
+    monkeypatch.setattr(worker, "queue", queue)
+
+    job = worker.enqueue_informe(sumar, 5, 6)
+    assert job.get_status() == "queued"
+    assert job.origin == "informes"


### PR DESCRIPTION
## Resumen
- añade prueba para evolución del endpoint `/metrics`
- incorpora test de configuración GET/POST en `nlp_intent`
- verifica la encolación de trabajos en el worker
- construye imágenes Docker de API y Web en CI
- documenta la estrategia de pruebas en contenedores

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab6b99b508833096a6ecfeacbc61a9