### PR TITLE
[docs] Añadir guía del worker y referencias

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Automatizaciones operativas para Metrotel: generación de informes, asistente co
   - **Telegram Bot** (primer canal de operación, con menú accesible por `/menu` o por intención). Incluye los flujos `/repetitividad` y `/sla` y un teclado opcional con atajos a ambos comandos. Ver [docs/bot.md](docs/bot.md) para guía rápida.
   - **Web Panel** (roles `admin`/`lector` configurables vía variables `WEB_ADMIN_USERNAME`/`WEB_ADMIN_PASSWORD` y `WEB_LECTOR_USERNAME`/`WEB_LECTOR_PASSWORD`, accesible por IP interna .28). Ver [docs/web.md](docs/web.md) para el plan del módulo.
   - **nlp_intent** (microservicio NLP para clasificación de intención).
+  - **Worker** para procesar tareas en segundo plano. Ver [docs/worker.md](docs/worker.md).
   - CLI opcional para utilidades.
 
 - **Integraciones externas**

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -7,3 +7,4 @@ Este archivo complementa las pautas generales de LAS-FOCAS.
 - Cada documento debe iniciar con el encabezado de tres líneas.
 - Mantener la documentación sincronizada con el código y requerimientos.
 - Registrar decisiones técnicas en `docs/decisiones.md`.
+- Documentar responsabilidades del servicio worker en `docs/worker.md`.

--- a/docs/worker.md
+++ b/docs/worker.md
@@ -1,0 +1,16 @@
+# Nombre de archivo: worker.md
+# Ubicación de archivo: docs/worker.md
+# Descripción: Responsabilidades del servicio worker
+
+El servicio **worker** procesa en segundo plano las tareas encoladas por la API utilizando Redis y RQ, evitando bloquear los servicios interactivos.
+
+## Responsabilidades principales
+- Consumir trabajos de la cola y ejecutar los generadores de informes (Repetitividad y SLA).
+- Manejar reintentos y tiempos máximos registrando logs estructurados.
+- Guardar los archivos producidos y notificar resultados a la API o al bot cuando corresponde.
+
+## Configuración básica
+- `REDIS_URL`: ubicación de la instancia de Redis utilizada como cola.
+- `WORKER_CONCURRENCY`: cantidad de procesos simultáneos para ejecutar trabajos.
+
+El módulo se inicia desde `modules/worker.py` y puede ejecutarse como servicio independiente.


### PR DESCRIPTION
## Resumen
- Documentación del servicio worker con sus responsabilidades y configuración básica.
- Enlaces al nuevo documento desde el README y AGENTS de documentación.

## Pruebas
- `pytest` *(errores durante la recolección: tests/test_api_metrics.py, tests/test_bot_conversations.py, tests/test_flows_builders.py, tests/test_health.py, tests/test_menu_keywords.py, tests/test_rate_limit_api.py, tests/test_repetitividad_flow_validations.py, tests/test_request_id.py, tests/test_worker_async.py)*


------
https://chatgpt.com/codex/tasks/task_e_68ab6d313e9883309533b9c927817707