### PR TITLE
[api/docs] Manejo global de excepciones y actualización de diagnóstico

### DIFF
--- a/docs/bot.md
+++ b/docs/bot.md
@@ -40,6 +40,7 @@ Los intentos de acceso de usuarios no incluidos en `TELEGRAM_ALLOWED_IDS` genera
 
 - Cada actualización del bot genera un `request_id` único que se adjunta a los logs.
 - La salida de `logging` está en formato JSON con los campos `service`, `action`, `tg_user_id` y `request_id`.
+- Las excepciones capturadas en los flujos se registran con `logger.exception`, lo que permite conservar la traza completa.
 
 ## Clasificación de intención
 

--- a/docs/infra.md
+++ b/docs/infra.md
@@ -52,6 +52,11 @@ jobs de la cola `informes` y genera los documentos sin bloquear a los clientes.
 - `ollama`: consulta `http://localhost:11434/api/tags`.
 - `pgadmin`: consulta `http://localhost:80/login`.
 
+## Diagnóstico
+
+- La API dispone de un manejador global de excepciones que registra la traza completa con `logger.exception`.
+- Los servicios deben emplear `logger.exception` dentro de los bloques `except` para facilitar la detección de fallos.
+
 ## Perfiles opcionales
 
 - `worker`: habilita `redis` y el servicio de tareas en segundo plano.


### PR DESCRIPTION
## Resumen
- Añadir manejador global de excepciones en la API para registrar trazas con `logger.exception`.
- Documentar la estrategia de diagnóstico en `docs/infra.md` y `docs/bot.md`.

## Pruebas
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab72de5fbc8330b6b26047b3c58ac7