### PR TITLE
[infra] Asegurar Redis con contraseña

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -31,6 +31,11 @@ LANG=es
 LOG_RAW_TEXT=false
 CACHE_TTL=300
 
+# Redis
+REDIS_PASSWORD=cambiar-este-password
+# Se carga desde /run/secrets/redis_password cuando está disponible
+REDIS_URL=redis://:${REDIS_PASSWORD}@redis:6379/0
+
 # Logging
 LOG_LEVEL=INFO
 LOG_DIR=/app/logs

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -186,6 +186,7 @@ services:
     image: redis:7-alpine
     container_name: lasfocas-redis
     restart: unless-stopped
+    command: ["redis-server", "--requirepass", "${REDIS_PASSWORD}"]
     expose:
       - "6379"
     healthcheck:
@@ -200,6 +201,8 @@ services:
           memory: "128M"
     networks:
       - lasfocas_net
+    secrets:
+      - redis_password
     profiles: ["worker"]
 
   ollama:
@@ -261,6 +264,8 @@ secrets:
     file: ./secrets/postgres_app_password
   postgres_readonly_password:
     file: ./secrets/postgres_readonly_password
+  redis_password:
+    file: ./secrets/redis_password
   telegram_bot_token:
     file: ./secrets/telegram_bot_token
   openai_api_key:

--- a/deploy/env.sample
+++ b/deploy/env.sample
@@ -31,6 +31,11 @@ LANG=es
 LOG_RAW_TEXT=false
 CACHE_TTL=300
 
+# Redis
+REDIS_PASSWORD=cambiar-este-password
+# Se carga desde /run/secrets/redis_password cuando está disponible
+REDIS_URL=redis://:${REDIS_PASSWORD}@redis:6379/0
+
 # Logging
 LOG_LEVEL=INFO
 LOG_DIR=/app/logs

--- a/docs/infra.md
+++ b/docs/infra.md
@@ -12,7 +12,7 @@
 - `api` publica `8000:8000` para acceso HTTP desde el host.
 - `nlp_intent` expone `8100` únicamente a la red interna.
 - `redis` expone `6379` solo a la red interna y se activa con el perfil `worker`.
-  Se utiliza como backend de la cola RQ que procesa informes de manera asíncrona.
+  Requiere autenticación con contraseña y se utiliza como backend de la cola RQ que procesa informes de manera asíncrona.
 - `ollama` expone `11434` solo a la red interna.
 - `pgadmin` (perfil opcional) publica `5050:80` para administración de PostgreSQL.
 
@@ -38,7 +38,8 @@
 ## Cola de tareas
 
 La API y el bot encolan trabajos en Redis mediante RQ. El servicio `worker` toma los
-jobs de la cola `informes` y genera los documentos sin bloquear a los clientes.
+jobs de la cola `informes` y genera los documentos sin bloquear a los clientes. El
+acceso a Redis está protegido mediante contraseña gestionada como secret.
 
 ## Healthchecks
 
@@ -78,7 +79,7 @@ Para más detalles consultar `docs/security.md`.
 
 El archivo `.env.sample` es la fuente única de verdad para todas las variables de entorno. Este listado resume su propósito y origen.
 
-Las credenciales sensibles (`POSTGRES_PASSWORD`, `POSTGRES_APP_PASSWORD`, `POSTGRES_READONLY_PASSWORD`, `TELEGRAM_BOT_TOKEN`, `OPENAI_API_KEY`, `SMTP_*`, `WEB_ADMIN_*`, `WEB_LECTOR_*`, `WEB_PASSWORD` y `NOTION_TOKEN`) se obtienen desde archivos en `/run/secrets/` cuando se utilizan Docker Secrets.
+Las credenciales sensibles (`POSTGRES_PASSWORD`, `POSTGRES_APP_PASSWORD`, `POSTGRES_READONLY_PASSWORD`, `REDIS_PASSWORD`, `TELEGRAM_BOT_TOKEN`, `OPENAI_API_KEY`, `SMTP_*`, `WEB_ADMIN_*`, `WEB_LECTOR_*`, `WEB_PASSWORD` y `NOTION_TOKEN`) se obtienen desde archivos en `/run/secrets/` cuando se utilizan Docker Secrets.
 
 ### Base de datos
 - `POSTGRES_HOST`: host del contenedor de PostgreSQL.
@@ -102,6 +103,10 @@ Las credenciales sensibles (`POSTGRES_PASSWORD`, `POSTGRES_APP_PASSWORD`, `POSTG
 - `LANG`: código de idioma por defecto.
 - `LOG_RAW_TEXT`: habilita el registro del texto completo recibido.
 - `CACHE_TTL`: tiempo en segundos para mantener en caché respuestas del NLP.
+
+### Redis
+- `REDIS_PASSWORD`: contraseña de acceso al servicio Redis.
+- `REDIS_URL`: dirección de conexión que incluye la contraseña y el puerto del servicio.
 
 ### Logging
 - `LOG_LEVEL`: nivel global de los registros (`DEBUG`, `INFO`, `WARNING`, etc.).

--- a/modules/worker.py
+++ b/modules/worker.py
@@ -15,7 +15,10 @@ from core.logging import configure_logging
 configure_logging("worker")
 logger = logging.getLogger("worker")
 
-REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+REDIS_URL = os.getenv(
+    "REDIS_URL",
+    f"redis://:{os.getenv('REDIS_PASSWORD', '')}@redis:6379/0",
+)
 IS_ASYNC = os.getenv("WORKER_ASYNC", "true").lower() == "true"
 redis_conn = Redis.from_url(REDIS_URL)
 queue = Queue("informes", connection=redis_conn, is_async=IS_ASYNC)

--- a/tests/test_worker_async.py
+++ b/tests/test_worker_async.py
@@ -7,6 +7,7 @@ import fakeredis
 from rq import Queue, SimpleWorker
 
 from modules import worker
+import importlib
 
 
 def sumar(x: int, y: int) -> int:
@@ -41,3 +42,13 @@ def test_enqueue_informe_devuelve_job(monkeypatch):
     job = worker.enqueue_informe(sumar, 5, 6)
     assert job.get_status() == "queued"
     assert job.origin == "informes"
+
+
+def test_worker_usa_password_en_url(monkeypatch):
+    """Confirma que REDIS_URL incorpora la contraseña cuando está definida."""
+    monkeypatch.setenv("REDIS_PASSWORD", "secreto")
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    importlib.reload(worker)
+    assert worker.REDIS_URL == "redis://:secreto@redis:6379/0"
+    monkeypatch.delenv("REDIS_PASSWORD", raising=False)
+    importlib.reload(worker)


### PR DESCRIPTION
## Resumen
- proteger Redis mediante contraseña obligatoria
- definir `REDIS_URL` con autenticación y actualizar worker
- documentar secretos y variables de Redis

## Pruebas
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab745fc5788330b73c9d3b87f21d43