### PR TITLE
[infra] Limitar exposición de API y pgAdmin con secrets

### DIFF
--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -53,8 +53,9 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-    ports:
-      - "8000:8000"
+    # Expuesto solo en la red interna; requerir proxy inverso para acceso externo
+    expose:
+      - "8000"
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://localhost:8000/health || exit 1"]
       interval: 10s
@@ -227,16 +228,20 @@ services:
       - lasfocas_net
 
   # (Opcional) pgAdmin. Levantar con: docker compose -f deploy/compose.yml --profile pgadmin up -d
+  # Solo para desarrollo
   pgadmin:
     image: dpage/pgadmin4:8
     container_name: lasfocas-pgadmin
     profiles: ["pgadmin"]
     restart: unless-stopped
     environment:
-      PGADMIN_DEFAULT_EMAIL: admin@local
-      PGADMIN_DEFAULT_PASSWORD: admin
+      PGADMIN_DEFAULT_EMAIL_FILE: /run/secrets/pgadmin_default_email
+      PGADMIN_DEFAULT_PASSWORD_FILE: /run/secrets/pgadmin_default_password
     ports:
       - "5050:80"
+    secrets:
+      - pgadmin_default_email
+      - pgadmin_default_password
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://localhost:80/login || exit 1"]
       interval: 10s
@@ -288,6 +293,10 @@ secrets:
     file: ./secrets/web_lector_password
   notion_token:
     file: ./secrets/notion_token
+  pgadmin_default_email:
+    file: ./secrets/pgadmin_default_email
+  pgadmin_default_password:
+    file: ./secrets/pgadmin_default_password
 
 networks:
   lasfocas_net:

--- a/docs/infra.md
+++ b/docs/infra.md
@@ -9,12 +9,12 @@
 ## Puertos
 
 - `postgres` expone `5432` solo a la red interna mediante `expose`.
-- `api` publica `8000:8000` para acceso HTTP desde el host.
+- `api` expone `8000` únicamente a la red interna; para acceder desde fuera se requiere un proxy inverso.
 - `nlp_intent` expone `8100` únicamente a la red interna.
 - `redis` expone `6379` solo a la red interna y se activa con el perfil `worker`.
   Requiere autenticación con contraseña y se utiliza como backend de la cola RQ que procesa informes de manera asíncrona.
 - `ollama` expone `11434` solo a la red interna.
-- `pgadmin` (perfil opcional) publica `5050:80` para administración de PostgreSQL.
+- `pgadmin` (perfil opcional) publica `5050:80` para administración de PostgreSQL; usar solo en desarrollo y con credenciales gestionadas como secrets.
 
 ## Volúmenes
 
@@ -73,7 +73,8 @@ Para más detalles consultar `docs/security.md`.
 ## Seguridad
 
 - `api`, `bot`, `web` y `worker` se ejecutan con un usuario no root dentro de sus contenedores, aplicando el principio de mínimos privilegios.
-- El servicio `web` solo expone el puerto `8080` dentro de la red interna; para publicarlo externamente se debe configurar un proxy inverso.
+- Los servicios `api` y `web` solo exponen sus puertos dentro de la red interna; para publicarlos externamente se debe configurar un proxy inverso que gestione TLS.
+- `pgadmin` se recomienda únicamente en desarrollo y sus credenciales se montan como secrets.
 
 ## Variables de entorno
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -5,12 +5,14 @@
 ## Secrets
 
 - Las credenciales se gestionan mediante **Docker Secrets** montados en `/run/secrets/*`.
-- Secretos usados: `postgres_password`, `postgres_app_password`, `postgres_readonly_password`, `telegram_bot_token`, `openai_api_key`, `smtp_host`, `smtp_user`, `smtp_password`, `smtp_from`, `web_admin_username`, `web_admin_password`, `web_lector_username`, `web_lector_password` y `notion_token`.
+- Secretos usados: `postgres_password`, `postgres_app_password`, `postgres_readonly_password`, `telegram_bot_token`, `openai_api_key`, `smtp_host`, `smtp_user`, `smtp_password`, `smtp_from`, `web_admin_username`, `web_admin_password`, `web_lector_username`, `web_lector_password`, `notion_token`, `pgadmin_default_email` y `pgadmin_default_password`.
 - Para crear un secreto, generar el archivo en `deploy/secrets/<nombre>`:
   ```bash
   echo "valor" > deploy/secrets/postgres_password
   echo "valor" > deploy/secrets/postgres_app_password
   echo "valor" > deploy/secrets/postgres_readonly_password
+  echo "correo" > deploy/secrets/pgadmin_default_email
+  echo "clave" > deploy/secrets/pgadmin_default_password
   ```
   Luego reiniciar los servicios con `docker compose -f deploy/compose.yml up -d`.
 - Para rotar un secreto, actualizar el archivo correspondiente y volver a desplegar el servicio que lo consume.
@@ -32,4 +34,5 @@
 - Los contenedores deben ejecutarse con usuarios no root cuando sea posible.
 - La base de datos utiliza usuarios específicos por servicio y roles de solo lectura cuando aplique.
 - Los puertos publicados al host se restringen únicamente a los necesarios.
-- El servicio `web` requiere un proxy inverso si se desea exponerlo fuera de la red interna.
+- La API y el servicio `web` deben estar detrás de un proxy inverso (como Nginx) para terminar TLS y aplicar filtros.
+- El servicio `pgadmin` se considera solo para desarrollo y sus credenciales se montan como secrets.


### PR DESCRIPTION
## Resumen
- API expuesta solo en la red interna y pensada para uso tras proxy inverso
- pgAdmin marcado para desarrollo y credenciales movidas a Docker Secrets
- Documentación de seguridad e infraestructura actualizada con nuevas prácticas

## Pruebas
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab758982ec8330950c98ca185b1d1c