### PR TITLE
[ci] Agregar pip-audit y análisis opcional con trivy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,12 @@ name: CI
 on:
   push:
   pull_request:
+  workflow_dispatch:
+    inputs:
+      trivy_scan:
+        description: 'Escanear imágenes Docker con Trivy'
+        required: false
+        default: 'false'
 
 jobs:
   test:
@@ -22,6 +28,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+      - name: Auditar dependencias con pip-audit
+        run: |
+          pip install pip-audit
+          pip-audit
       - name: Ejecutar pytest con cobertura
         run: |
           pytest --cov=. --cov-report=xml
@@ -44,3 +54,25 @@ jobs:
         run: docker build -t las-focas-api:ci ./api
       - name: Construir imagen Web
         run: docker build -t las-focas-web:ci ./web
+  trivy-scan:
+    runs-on: ubuntu-latest
+    needs: build-images
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.trivy_scan == 'true' }}
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Configurar Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Construir imagen API
+        run: docker build -t las-focas-api:ci ./api
+      - name: Escanear imagen API con Trivy
+        uses: aquasecurity/trivy-action@0.16.0
+        with:
+          image-ref: las-focas-api:ci
+      - name: Construir imagen Web
+        run: docker build -t las-focas-web:ci ./web
+      - name: Escanear imagen Web con Trivy
+        uses: aquasecurity/trivy-action@0.16.0
+        with:
+          image-ref: las-focas-web:ci

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ De igual forma, el servicio `ollama` expone `11434` solo dentro de la red intern
 
 ## 📪 CI/CD
 
-**CI (Integración Continua):** `pytest` y `ruff` se ejecutan en cada push o pull request mediante [GitHub Actions](docs/ci.md).\
+**CI (Integración Continua):** `pytest`, `ruff` y `pip-audit` se ejecutan en cada push o pull request mediante [GitHub Actions](docs/ci.md). El escaneo de imágenes con `trivy` puede activarse manualmente.
 **CD (Entrega Continua):** despliegue automático opcional.
 
 ---

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -8,13 +8,21 @@ El proyecto ejecuta un flujo de **integración continua** mediante GitHub Action
 
 1. **Checkout** del repositorio.
 2. **Instalación de dependencias** definidas en `requirements.txt`.
-3. Ejecución de las **pruebas** con `pytest` generando reporte de cobertura.
-4. **Carga** del archivo `coverage.xml` como artefacto de la ejecución.
-5. Análisis de estilo y calidad de código con **`ruff`**.
-6. Construcción de las imágenes Docker de **API** y **Web**.
+3. **Auditoría de dependencias** con `pip-audit`.
+4. Ejecución de las **pruebas** con `pytest` generando reporte de cobertura.
+5. **Carga** del archivo `coverage.xml` como artefacto de la ejecución.
+6. Análisis de estilo y calidad de código con **`ruff`**.
+7. Construcción de las imágenes Docker de **API** y **Web**.
+
+Además, de forma manual puede activarse un job `trivy-scan` que recompila las imágenes y las analiza con `trivy` en busca de vulnerabilidades.
 
 La finalidad es garantizar que el código pase las pruebas automatizadas y cumpla las reglas de estilo antes de integrarse en la rama principal.
 
 ## Pruebas en contenedores
 
 El job `build-images` compila las imágenes `las-focas-api:ci` y `las-focas-web:ci` usando `docker build`. Este paso detecta de forma temprana errores en los `Dockerfile` y asegura que los servicios puedan ejecutarse en contenedores.
+
+## Reportes y políticas de bloqueo
+
+- **`pip-audit`** genera un listado de dependencias vulnerables junto con la severidad y el identificador de cada CVE. Cualquier vulnerabilidad detectada provoca el fallo del job `test`, bloqueando el merge hasta que se actualicen las dependencias afectadas.
+- **`trivy`** muestra vulnerabilidades del sistema base y de los paquetes presentes en las imágenes. El job `trivy-scan` es opcional y está marcado con `continue-on-error`, por lo que sus hallazgos no detienen el flujo de CI. Se recomienda corregir las vulnerabilidades críticas y volver a ejecutar el análisis.


### PR DESCRIPTION
## Resumen
- Ejecutar pip-audit tras instalar dependencias en el flujo de CI
- Incorporar job manual trivy-scan para auditar imágenes Docker
- Documentar interpretación de reportes y políticas de bloqueo

## Testing
- `pip-audit` (falla: dependencias con vulnerabilidades)
- `pytest`
- `ruff check .`
- `apt-get install -y trivy` (falla: paquete no encontrado)


------
https://chatgpt.com/codex/tasks/task_e_68ab769642b88330bc6e29203c29f734