### PR TITLE
[deploy] Documentar secrets y permitir contraseña por entorno

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,10 +221,21 @@ sudo usermod -aG docker "$USER"
 
 **Primer arranque**
 
-```bash
-cp .env.sample .env
-docker compose -f deploy/compose.yml up -d --build
-```
+1. Copiar el archivo de variables de entorno de ejemplo:
+
+   ```bash
+   cp .env.sample .env
+   ```
+
+2. Crear los archivos de texto en `deploy/secrets/` que contendrán las credenciales. El nombre del archivo identifica la variable que se inyectará (por ejemplo: `postgres_password`, `web_admin_password`). Cada archivo debe incluir únicamente el valor de la clave y nada más.
+
+3. Iniciar el stack de contenedores:
+
+   ```bash
+   docker compose -f deploy/compose.yml up -d --build
+   ```
+
+   Para pruebas rápidas, puede comentarse la referencia a `secrets` en `deploy/compose.yml` y utilizar las variables definidas en `.env`.
 
 Luego de iniciar los contenedores, puede verificarse el estado del servicio:
 

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -13,7 +13,9 @@ services:
     environment:
       POSTGRES_DB: ${POSTGRES_DB}
       POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      # Si no se define POSTGRES_PASSWORD_FILE, se utilizará la contraseña de la variable anterior
+      POSTGRES_PASSWORD_FILE: ${POSTGRES_PASSWORD_FILE:-/run/secrets/postgres_password}
       POSTGRES_APP_PASSWORD_FILE: /run/secrets/postgres_app_password
       POSTGRES_READONLY_PASSWORD_FILE: /run/secrets/postgres_readonly_password
     expose:
@@ -265,6 +267,7 @@ volumes:
 secrets:
   postgres_password:
     file: ./secrets/postgres_password
+    optional: true
   postgres_app_password:
     file: ./secrets/postgres_app_password
   postgres_readonly_password:

--- a/docs/infra.md
+++ b/docs/infra.md
@@ -23,6 +23,12 @@
 - `./db/init.sql` y `./db/init_users.sh` se montan de forma de solo lectura para inicializar la base y crear usuarios.
 - `ollama_data`: guarda los modelos descargados en `/root/.ollama`.
 
+## Secrets
+
+- Los secretos se almacenan como archivos de texto en `deploy/secrets/`. El nombre de cada archivo coincide con la variable que el servicio espera (ej.: `postgres_password`, `web_admin_password`).
+- Para pruebas rápidas puede comentarse la referencia a `secrets` en `deploy/compose.yml` y utilizar las variables definidas en `.env`.
+- En el servicio `postgres`, si `POSTGRES_PASSWORD_FILE` no está definido, la imagen utilizará el valor de `POSTGRES_PASSWORD`.
+
 ## Contextos de build
 
 - `api`: utiliza `../api` como contexto de compilación ya que el archivo `compose.yml` se ubica en `deploy/`.


### PR DESCRIPTION
## Resumen
- detallar creación de archivos en `deploy/secrets/` para el primer arranque
- explicar cómo usar variables de `.env` comentando los `secrets`
- permitir que `postgres` use `POSTGRES_PASSWORD` si no se define `POSTGRES_PASSWORD_FILE`

## Pruebas
- `pytest`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68ac778bf70883308ddb6e7359e37cd5