### PR TITLE
[infra] Añadir perfil bot y actualizar documentación

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,12 @@ sudo usermod -aG docker "$USER"
    docker compose -f deploy/compose.yml up -d --build
    ```
 
+   El bot de Telegram se inicia solo cuando se especifica el perfil `bot`:
+
+   ```bash
+   docker compose -f deploy/compose.yml --profile bot up -d
+   ```
+
    Para pruebas rápidas, puede comentarse la referencia a `secrets` en `deploy/compose.yml` y utilizar las variables definidas en `.env`.
 
 Luego de iniciar los contenedores, puede verificarse el estado del servicio:
@@ -237,7 +243,10 @@ cd LAS-FOCAS
 cp .env.sample .env
 cp .env deploy/.env
 docker compose -f deploy/compose.yml up -d --build
+docker compose -f deploy/compose.yml --profile bot up -d
 ```
+
+El segundo comando levanta el bot de Telegram.
 
 ---
 

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -157,6 +157,7 @@ services:
           memory: "256M"
     networks:
       - lasfocas_net
+    profiles: ["bot"]
 
   worker:
     build:

--- a/docs/infra.md
+++ b/docs/infra.md
@@ -71,6 +71,8 @@ acceso a Redis está protegido mediante contraseña gestionada como secret.
 
 ## Perfiles opcionales
 
+- `bot`: inicia el servicio de Telegram Bot.
+  Se activa con `docker compose -f deploy/compose.yml --profile bot up -d`.
 - `worker`: habilita `redis` y el servicio de tareas en segundo plano.
 - `pgadmin`: expone una interfaz web para administración de PostgreSQL.
   Se activa con `docker compose -f deploy/compose.yml --profile pgadmin up -d`.


### PR DESCRIPTION
## Resumen
- activar el bot mediante un perfil opcional en docker compose
- documentar en README y docs/infra el uso de `--profile bot`

## Pruebas
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac7d4fe2ac833084f453347cf9c57c