### PR TITLE
[web] Redirigir a login cuando faltan credenciales

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -40,6 +40,8 @@ El servicio inicializa el log mediante `configure_logging("web")`, lo que emite 
 - Credenciales diferenciadas por rol:
   - `WEB_ADMIN_USERNAME` / `WEB_ADMIN_PASSWORD`.
   - `WEB_LECTOR_USERNAME` / `WEB_LECTOR_PASSWORD`.
+- Si no se envían credenciales o el encabezado es inválido, el servicio redirige a `/login`.
+- Solo cuando las credenciales son erróneas se devuelve 401 con `WWW-Authenticate`.
 - Las rutas pueden restringirse según el rol detectado.
 - Futuro: integrar SSO interno.
 

--- a/tests/test_web_auth.py
+++ b/tests/test_web_auth.py
@@ -25,11 +25,12 @@ def get_client(admin_user: str, admin_pass: str) -> TestClient:
     return TestClient(module.app)
 
 
-def test_denied_without_credentials() -> None:
-    """El acceso sin credenciales debe ser rechazado."""
+def test_redirect_without_credentials() -> None:
+    """El acceso sin credenciales redirige al formulario de login."""
     client = get_client("user", "pass")
-    response = client.get("/")
-    assert response.status_code == 401
+    response = client.get("/", allow_redirects=False)
+    assert response.status_code == 307
+    assert response.headers["location"] == "/login"
 
 
 def test_authorized_access() -> None:
@@ -45,4 +46,12 @@ def test_denied_with_invalid_credentials() -> None:
     client = get_client("user", "pass")
     response = client.get("/", auth=("user", "wrong"))
     assert response.status_code == 401
+
+
+def test_redirect_on_malformed_header() -> None:
+    """Un encabezado Authorization inválido redirige a /login."""
+    client = get_client("user", "pass")
+    response = client.get("/", headers={"Authorization": "Basic ???"}, allow_redirects=False)
+    assert response.status_code == 307
+    assert response.headers["location"] == "/login"
 

--- a/web/main.py
+++ b/web/main.py
@@ -10,7 +10,7 @@ import time
 from pathlib import Path
 
 from fastapi import Depends, FastAPI, HTTPException, Request, Response, status
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from starlette.middleware.base import BaseHTTPMiddleware
 
@@ -45,20 +45,14 @@ class BasicAuthMiddleware(BaseHTTPMiddleware):
         auth = request.headers.get("Authorization")
         if not auth or not auth.startswith("Basic "):
             logger.warning("action=basic_auth sin_credenciales")
-            return Response(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                headers={"WWW-Authenticate": "Basic"},
-            )
+            return RedirectResponse(url="/login")
 
         try:
             decoded = base64.b64decode(auth.split(" ")[1]).decode("utf-8")
             user, pwd = decoded.split(":", 1)
         except Exception:  # noqa: BLE001
             logger.warning("action=basic_auth error_decodificar")
-            return Response(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                headers={"WWW-Authenticate": "Basic"},
-            )
+            return RedirectResponse(url="/login")
 
         if user == self.admin_user and pwd == self.admin_pass:
             request.state.role = "admin"


### PR DESCRIPTION
## Resumen
- Redirección a `/login` en ausencia de credenciales o al fallar la decodificación
- Se mantiene `WWW-Authenticate` únicamente ante credenciales inválidas
- Pruebas y documentación actualizadas para reflejar el nuevo flujo

## Pruebas
- `pytest tests/test_web_auth.py tests/test_web_login.py tests/test_web_roles.py tests/test_web_metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac82ec18f8833080ed6a995811ba58