### PR TITLE
[docs] Definir clave de lector por defecto y advertir uso

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -64,7 +64,7 @@ WEB_ADMIN_PASSWORD=cambiar-este-password
 # Se carga desde /run/secrets/web_admin_password cuando está disponible
 WEB_LECTOR_USERNAME=lector
 # Se carga desde /run/secrets/web_lector_username cuando está disponible
-WEB_LECTOR_PASSWORD=cambiar-esta-password
+WEB_LECTOR_PASSWORD=lectura
 # Se carga desde /run/secrets/web_lector_password cuando está disponible
 
 # Variables heredadas para compatibilidad con versiones anteriores

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ La lista completa de variables de entorno se encuentra en [.env.sample](.env.sam
 - **Redis**: `REDIS_PASSWORD` y `REDIS_URL`, necesarias para habilitar la caché y las colas internas.
 - **Panel Web**: credenciales `WEB_ADMIN_USERNAME` / `WEB_ADMIN_PASSWORD` y `WEB_LECTOR_USERNAME` / `WEB_LECTOR_PASSWORD` para los roles administrativos y de lectura.
 
+Las credenciales definidas en este archivo (por ejemplo `WEB_LECTOR_PASSWORD=lectura`) son exclusivas para pruebas y deben sustituirse antes de cualquier despliegue en producción.
+
 La variable `WORK_HOURS` permite ajustar el cálculo del TTR al horario laboral; en `false` se usa el total de horas calendario.
 Las solicitudes a la API deben incluir el encabezado `X-API-Key`; el límite se calcula por clave (o por IP si falta).
 


### PR DESCRIPTION
## Resumen
- Fijar `WEB_LECTOR_PASSWORD=lectura` en `.env.sample`
- Advertir en `README.md` que las credenciales del archivo `.env.sample` son solo de prueba y deben reemplazarse en producción

## Pruebas
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac846c7af08330a33f26e07238968b