### PR TITLE
[web] Instalar dependencias desde requirements

### DIFF
--- a/docs/decisiones.md
+++ b/docs/decisiones.md
@@ -29,3 +29,10 @@
 - **Decisión:** Actualizar `requirements.txt` a `Jinja2==3.1.6`, `packaging==24.1`, `Pygments==2.17.2` y `urllib3==2.5.0`.
 - **Alternativas:** Mantener versiones vulnerables y aplicar mitigaciones manuales.
 - **Impacto:** Mejora la seguridad al eliminar CVEs conocidos y mantiene el pipeline de CI en verde.
+
+## 2025-08-25 — Instalación de dependencias desde requirements en el servicio web
+
+- **Contexto:** El `Dockerfile` del servicio web instalaba `fastapi` y `uvicorn` manualmente.
+- **Decisión:** Copiar `requirements.txt` al contenedor e instalarlo con `pip install --no-cache-dir -r requirements.txt`.
+- **Alternativas:** Mantener la instalación manual de paquetes base.
+- **Impacto:** Centraliza las versiones en el archivo de dependencias y simplifica futuras actualizaciones.

--- a/docs/web.md
+++ b/docs/web.md
@@ -29,7 +29,9 @@ El repositorio incluye un microservicio en `web/main.py` que utiliza **FastAPI**
 - `GET /login` entrega un formulario de acceso aún en desarrollo.
 - `GET /metrics` expone métricas simples sin autenticación.
 
-Este servicio se construye con `web/Dockerfile` sobre la imagen `python:3.11-slim` y se despliega mediante `deploy/compose.yml` como servicio `web`, exponiendo el puerto `8080` solo a la red interna. Para publicar externamente se requiere un proxy inverso.
+ Este servicio se construye con `web/Dockerfile` sobre la imagen `python:3.11-slim` y se despliega mediante `deploy/compose.yml` como servicio `web`, exponiendo el puerto `8080` solo a la red interna. Para publicar externamente se requiere un proxy inverso.
+
+Durante la etapa de construcción, el contenedor copia el `requirements.txt` del proyecto e instala sus dependencias con `pip install --no-cache-dir -r requirements.txt`, evitando la instalación manual de **FastAPI** y **Uvicorn** y garantizando que las versiones provengan del archivo de dependencias compartido.
 
 ## Logging
 

--- a/tests/test_web_auth.py
+++ b/tests/test_web_auth.py
@@ -28,7 +28,7 @@ def get_client(admin_user: str, admin_pass: str) -> TestClient:
 def test_redirect_without_credentials() -> None:
     """El acceso sin credenciales redirige al formulario de login."""
     client = get_client("user", "pass")
-    response = client.get("/", allow_redirects=False)
+    response = client.get("/", follow_redirects=False)
     assert response.status_code == 307
     assert response.headers["location"] == "/login"
 
@@ -51,7 +51,7 @@ def test_denied_with_invalid_credentials() -> None:
 def test_redirect_on_malformed_header() -> None:
     """Un encabezado Authorization inválido redirige a /login."""
     client = get_client("user", "pass")
-    response = client.get("/", headers={"Authorization": "Basic ???"}, allow_redirects=False)
+    response = client.get("/", headers={"Authorization": "Basic ???"}, follow_redirects=False)
     assert response.status_code == 307
     assert response.headers["location"] == "/login"
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -6,9 +6,12 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-RUN pip install --no-cache-dir fastapi==0.110.1 uvicorn[standard]==0.29.0 \
+# Copiamos el archivo de dependencias compartido y lo instalamos sin caché
+COPY ../requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r /app/requirements.txt \
     && useradd -ms /bin/bash appuser
 
+# Incorporamos el código fuente del servicio
 COPY . /app
 
 USER appuser


### PR DESCRIPTION
## Resumen
- usar `requirements.txt` al construir la imagen web, eliminando instalaciones manuales de FastAPI y Uvicorn
- documentar la nueva estrategia de dependencias del servicio web y registrar la decisión técnica
- ajustar las pruebas del panel web al nuevo parámetro `follow_redirects`

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac86360b608330a41294277e5b4375