### PR TITLE
[deploy] Agregar carpeta de secrets y documentar credenciales

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ sudo usermod -aG docker "$USER"
 
 **Primer arranque**
 
+Antes de iniciar los contenedores, coloca las credenciales en `deploy/secrets/`. El repositorio versiona esta carpeta vacía mediante un archivo `.gitkeep` para conservarla.
+
 1. Copiar el archivo de variables de entorno de ejemplo y replicarlo para `deploy`:
 
    ```bash

--- a/docs/infra.md
+++ b/docs/infra.md
@@ -26,6 +26,7 @@
 ## Secrets
 
 - Los secretos se almacenan como archivos de texto en `deploy/secrets/`. El nombre de cada archivo coincide con la variable que el servicio espera (ej.: `postgres_password`, `web_admin_password`).
+- El repositorio conserva esta carpeta vacía mediante un archivo `.gitkeep` para que exista antes de cargar las credenciales.
 - Para pruebas rápidas puede comentarse la referencia a `secrets` en `deploy/compose.yml` y utilizar las variables definidas en `.env`.
 - En el servicio `postgres`, si `POSTGRES_PASSWORD_FILE` no está definido, la imagen utilizará el valor de `POSTGRES_PASSWORD`.
 


### PR DESCRIPTION
## Resumen
- Añadir carpeta `deploy/secrets/` con `.gitkeep` para preservar la ruta.
- Aclarar en README e infraestructura que las credenciales deben colocarse en `deploy/secrets/` antes de iniciar el stack.

## Pruebas
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac8775e2288330b4d440116dfd4e0f